### PR TITLE
fix desc typo in KIC 8435766 b

### DIFF
--- a/systems/KIC 8435766.xml
+++ b/systems/KIC 8435766.xml
@@ -24,7 +24,7 @@
 			<period errorminus="0.00000008" errorplus="0.00000008">0.35500745</period>
 			<inclination errorminus="9" errorplus="6">81</inclination>
 			<transittime errorminus="0.00015" errorplus="0.00015" unit="BJD">2454953.95984</transittime>
-			<description>The Earth-sized planet KIC 8435766 b was identified in the Kepler database and confirmed to be a transiting planet (as apposed to an eclipsing binary) through the absence of ellipsoidal or radial velocity variations. The planet has a dayside temperature of 2300K-3100K.</description>
+			<description>The Earth-sized planet KIC 8435766 b was identified in the Kepler database and confirmed to be a transiting planet (as opposed to an eclipsing binary) through the absence of ellipsoidal or radial velocity variations. The planet has a dayside temperature of 2300K-3100K.</description>
 			<discoverymethod>transit</discoverymethod>
 			<lastupdate>13/05/20</lastupdate>
 			<discoveryyear>2013</discoveryyear>


### PR DESCRIPTION
I attempted repeated to use Exoplanet's built-in editing function using iOS 6.1.3 10B329, but it crashes with 'NSInvalidArgumentException', reason: 'Application tried to presetn a nil modal view controller on target <RawDataController: 0x1e96ef90>.'
