### PR TITLE
include HAT-P-44b transit time and replace mass by adopted model

### DIFF
--- a/systems/HAT-P-44.xml
+++ b/systems/HAT-P-44.xml
@@ -18,7 +18,7 @@
 			<name>GSC 3465-00123 b</name>
 			<name>2MASS 14123457+4700528 b</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="0.077" errorplus="0.077">0.347</mass>
+			<mass errorminus="0.031" errorplus="0.031">0.392</mass>
 			<radius errorminus="0.074" errorplus="0.145">1.28</radius>
 			<temperature errorminus="42" errorplus="67">1126</temperature>
 			<semimajoraxis errorminus="0.0007" errorplus="0.0007">0.0507</semimajoraxis>
@@ -26,6 +26,7 @@
 			<inclination errorminus="0.5" errorplus="0.5">89</inclination>
 			<periastron errorminus="84" errorplus="84">98</periastron>
 			<description>This planet was discovered by the HATNet transit survey. Follow up observations to measure the radial velocity of the star confirmed the planetary nature.</description>
+			<transittime errorminus="0.00136" errorplus="0.00136">2455352.83957</transittime>
 			<discoverymethod>transit</discoverymethod>
 			<lastupdate>13/08/16</lastupdate>
 			<discoveryyear>2013</discoveryyear>


### PR DESCRIPTION
Transit time of HAT-P-44b has been added and the planet mass corrected.
