### PR TITLE
Add discovery data for Solar System planets

### DIFF
--- a/systems/Sun.xml
+++ b/systems/Sun.xml
@@ -21,7 +21,8 @@
 			<periastron>77.45771895</periastron>
 			<ascendingnode>48.33961819</ascendingnode>
 			<longitude>252.25166724</longitude>
-			<discoverymethod>imaging</discoverymethod>				
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>-200</discoveryyear>				
 			<description>Mercury is the innermost planet in the Solar System.</description>
 			<lastupdate>12/01/01</lastupdate>		
 		</planet>
@@ -38,7 +39,8 @@
 			<periastron>131.76755713</periastron>
 			<ascendingnode>76.67261496</ascendingnode>
 			<longitude>181.97970850</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>-200</discoveryyear>	
 			<description>Venus is the second planet from the Sun.</description>
 			<lastupdate>12/01/01</lastupdate>
 		</planet>
@@ -55,7 +57,8 @@
 			<periastron>102.93005885</periastron>
 			<ascendingnode>-5.11260389</ascendingnode>
 			<longitude>100.46691572</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>-100000</discoveryyear>	
 			<description>Earth is the only known planet able to sustain life.</description>
 			<lastupdate>12/01/01</lastupdate>
 		</planet>
@@ -72,7 +75,8 @@
 			<periastron>-23.91744784</periastron>
 			<ascendingnode>49.71320984</ascendingnode>
 			<longitude>-4.56813164</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>-200</discoveryyear>	
 			<description>Mars is named after the Roman god of war and often called the red planet.</description>
 			<lastupdate>12/01/01</lastupdate>
 		</planet>
@@ -89,7 +93,8 @@
 			<periastron>14.27495244</periastron>
 			<ascendingnode>100.29282654</ascendingnode>
 			<longitude>34.33479152</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>-200</discoveryyear>	
 			<description>Jupiter is two and a half times the mass of all the other planets in the Solar System.</description>
 			<lastupdate>12/01/01</lastupdate>
 		</planet>
@@ -106,7 +111,8 @@
 			<periastron>92.86136063</periastron>
 			<ascendingnode>113.63998702</ascendingnode>
 			<longitude>50.07571329</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>-200</discoveryyear>	
 			<description>Saturn is best known for its extensive ring system.</description>
 			<lastupdate>12/01/01</lastupdate>
 		</planet>
@@ -123,10 +129,10 @@
 			<periastron>172.43404441</periastron>
 			<ascendingnode>73.96250215</ascendingnode>
 			<longitude>314.20276625</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>1781</discoveryyear>	
 			<description>Uranus is visible with the naked eye but has never been recognized as a planet by ancient observers.</description>
 			<lastupdate>12/01/01</lastupdate>
-			<discoveryyear>1781</discoveryyear>
 		</planet>
 		<planet>
 			<name>Neptune</name>
@@ -141,10 +147,10 @@
 			<periastron>46.68158724</periastron>
 			<ascendingnode>131.78635853</ascendingnode>
 			<longitude>304.22289287</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>1846</discoveryyear>	
 			<description>Neptune is the fourth largest planet in the Solar System.</description>
 			<lastupdate>12/01/01</lastupdate>
-			<discoveryyear>1846</discoveryyear>
 		</planet>
 		<planet>
 			<name>Pluto</name>
@@ -159,10 +165,10 @@
 			<periastron>224.09702598</periastron>
 			<ascendingnode>110.30167986</ascendingnode>
 			<longitude>238.96535011</longitude>
-			<discoverymethod>imaging</discoverymethod>	
+			<discoverymethod>imaging</discoverymethod>
+			<discoveryyear>1930</discoveryyear>	
 			<description>Pluto is officially categorized as a minor planet by the International Astronomical Union.</description>
 			<lastupdate>12/01/01</lastupdate>
-			<discoveryyear>1930</discoveryyear>
 		</planet>
 	</star>
 </system>


### PR DESCRIPTION
Unless there's some reason for excluding it that I'm missing, there are applications where it would be helpful to have discovery data (year and method) for Solar System planets. Some of values may be approximate (e.g. for the earliest discoveries) or a bit of a stretch (was Earth discovered by 'imaging'); but for most uses these should suffice and in any case should do no harm (no one should be using the absence of a discovery method, for example, as his or her test for a Solar System planet).
