### PR TITLE
Fix mass of KOI-55 b

### DIFF
--- a/systems/KOI-55.xml
+++ b/systems/KOI-55.xml
@@ -17,7 +17,7 @@
 		<planet>
 			<name>KOI-55 b</name>
 			<list>Confirmed planets</list>
-			<mass>0.014</mass>
+			<mass>0.0014</mass>
 			<radius>0.068</radius>
 			<period>0.2401</period>
 			<semimajoraxis>0.006</semimajoraxis>


### PR DESCRIPTION
Fix mass of KOI-55 b to match [discovery reference](http://www.nature.com/nature/journal/v480/n7378/pdf/nature10631.pdf) (Table 1).
