### PR TITLE
Updated planet mass and radius from Smith et al 2013

### DIFF
--- a/systems/WASP-71.xml
+++ b/systems/WASP-71.xml
@@ -21,8 +21,8 @@
 			<name>WASP-71 b</name>
 			<name>TYC 30-116-1 b</name>
 			<list>Confirmed planets</list>
-			<mass>2.258</mass>
-			<radius>1.50</radius>
+			<mass errorminus="0.08" errorplus="0.08">2.242</mass>
+			<radius errorminus="0.13" errorplus="0.13">1.46</radius>
 			<rossitermclaughlin>19.8</rossitermclaughlin>
 			<period>2.9036747</period>
 			<semimajoraxis>0.04631</semimajoraxis>
@@ -31,7 +31,7 @@
 			<transittime errorminus="0.00070" errorplus="0.00070" unit="BJD">2455738.85050</transittime>
 			<description>WASP-71 b is a highly-irradiated planet which transits an  evolved F8-type star every 2.9 days. The planet is larger than Jupiter but less dense.</description>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>12/11/14</lastupdate>
+			<lastupdate>14/01/26</lastupdate>
 			<discoveryyear>2012</discoveryyear>
 			<temperature>1888.1</temperature>
 		</planet>


### PR DESCRIPTION
I have taken these values of mass and radius for WASP-71b from 2013A&A...552A.120S which is the only paper on this object. The previous values seem to be the same as in exoplanet.eu.
