### PR TITLE
Replace masses of Kepler-23b and c by upper limits

### DIFF
--- a/systems/Kepler-23.xml
+++ b/systems/Kepler-23.xml
@@ -28,7 +28,7 @@
 			<name>KOI 168.01</name>
 			<list>Confirmed planets</list>
 			<radius>0.1731475</radius>
-			<mass>0.8</mass>
+			<mass upperlimit="0.8" />
 			<period>7.1073</period>
 			<semimajoraxis>0.075</semimajoraxis>
 			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-23 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet and should be considered an upper limit.</description>
@@ -43,7 +43,7 @@
 			<name>KOI 168.02</name>
 			<list>Confirmed planets</list>
 			<radius>0.2916169</radius>
-			<mass>2.7</mass>
+			<mass upperlimit="2.7" />
 			<period>10.7421</period>
 			<semimajoraxis>0.099</semimajoraxis>
 			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-23 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet and should be considered an upper limit.</description>


### PR DESCRIPTION
Use upper limits for the masses of Kepler-23b and c based on dynamical stability.
