### PR TITLE
Added upper limits on the masses of Kepler-24 b and c

### DIFF
--- a/systems/Kepler-24.xml
+++ b/systems/Kepler-24.xml
@@ -20,6 +20,7 @@
 			<name>KOI 1102.02</name>
 			<list>Confirmed planets</list>
 			<radius>0.21871271</radius>
+			<mass upperlimit="1.6" />
 			<period>8.1453</period>
 			<semimajoraxis>0.08</semimajoraxis>
 			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-24 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet.</description>
@@ -34,6 +35,7 @@
 			<name>KOI 1102.01</name>
 			<list>Confirmed planets</list>
 			<radius>0.25516482</radius>
+			<mass upperlimit="1.6" />
 			<period>12.333</period>
 			<semimajoraxis>0.106</semimajoraxis>
 			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-24 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet.</description>


### PR DESCRIPTION
Upper limits from Ford et al 2012 (http://dx.doi.org/10.1088/0004-637X/750/2/113)

Closes #101
