### PR TITLE
Alternative name added (PH-2)

### DIFF
--- a/systems/PH-2.xml
+++ b/systems/PH-2.xml
@@ -17,6 +17,7 @@
 			<name>KIC 12735740 b</name>
 			<name>2MASS 19190326+5157453 b</name>
 			<name>Planet Hunters 2 b</name>
+			<name>Kepler-86 b</name>
 			<list>Confirmed planets</list>
 			<period>282.5255</period>
 			<eccentricity>0.41</eccentricity>
@@ -32,7 +33,7 @@
 			
 Image Credit: H. Giguere, M. Giguere/Yale University</imagedescription>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/01/06</lastupdate>
+			<lastupdate>14/03/25</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<istransiting>1</istransiting>
 		</planet>


### PR DESCRIPTION
Added alternative name "Kepler-86 b". #144
