### PR TITLE
Deleted error bars with zero value

### DIFF
--- a/systems/Kepler-381.xml
+++ b/systems/Kepler-381.xml
@@ -11,7 +11,7 @@
 		<name>KIC 8013439</name>
 		<temperature errorminus="00" errorplus="100">6152</temperature>
 		<radius errorminus=".350" errorplus="0.350">1.568</radius>
-		<mass errorminus="" errorplus="">1.3780</mass>
+		<mass>1.3780</mass>
 		<planet>
 			<name>Kepler-381 c</name>
 			<name>KOI-2352 c</name>


### PR DESCRIPTION
i think, that error bars with value Zero are not senseful. i found no other information in literature
