### PR TITLE
 Positional information for binaries without orbit information

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -85,7 +85,7 @@ validtags = [
     "longitude", "imagedescription", "image", "age", "declination", "rightascension",
     "metallicity", "inclination", "spectraltype", "binary", "planet", "periastron", "star",
     "mass", "eccentricity", "radius", "temperature", "videolink", "transittime", 
-    "spinorbitalignment", "istransiting", "separation", "projected", "positionangle"]
+    "spinorbitalignment", "istransiting", "separation", "positionangle"]
 validattributes = [
     "error",
     "errorplus",
@@ -95,7 +95,7 @@ validattributes = [
     "lowerlimit",
     "type"]
 validdiscoverymethods = ["RV", "transit", "timing", "imaging", "microlensing"]
-tagsallowmultiple = ["list", "name", "planet", "star", "binary"]
+tagsallowmultiple = ["list", "name", "planet", "star", "binary", "separation"]
 numerictags = ["mass", "radius", "ascnedingnode", "discoveryyear", "semimajoraxis", "period",
     "magV", "magJ", "magH", "magR", "magB", "magK", "magI", "distance", "longitude", "age",
     "metallicity", "inclination", "periastron", "eccentricity", "temperature", "transittime",

--- a/systems/16 Cygni.xml
+++ b/systems/16 Cygni.xml
@@ -4,9 +4,9 @@
 	<declination>+50 31 03</declination>
 	<distance>21.41</distance>
 	<binary>
-		<separation>39.8</separation>
+		<separation unit="arcsec">39.8</separation>
+		<separation unit="AU">852</separation>
 		<positionangle>313</positionangle>
-		<projected>852</projected>
 		<star>
 			<name>16 Cygni B</name>
 			<name>16 Cyg B</name>
@@ -35,9 +35,9 @@
 			<temperature>5766.0</temperature>
 		</star>
 		<binary>
-			<separation>3.4</separation>
+			<separation unit="arcsec">3.4</separation>
+			<separation unit="AU">73</separation>
 			<positionangle>209</positionangle>
-			<projected>73</projected>
 			<star>
 				<name>16 Cygni A</name>
 				<name>16 Cyg A</name>

--- a/systems/55 Cancri.xml
+++ b/systems/55 Cancri.xml
@@ -5,9 +5,9 @@
 	<declination>+28 20 02</declination>
 	<distance errorminus="0.1" errorplus="0.1">12.3</distance>
 	<binary>
-		<separation>84</separation>
+		<separation unit="arcsec">84</separation>
+		<separation unit="AU">1033</separation>
 		<positionangle>130</positionangle>
-		<projected>1033</projected>
 		<star>
 			<mass errorminus="0.015" errorplus="0.015">0.905</mass>
 			<radius errorminus="0.010" errorplus="0.010">0.943</radius>

--- a/systems/83 Leonis.xml
+++ b/systems/83 Leonis.xml
@@ -4,9 +4,9 @@
 	<declination>+03 00 22</declination>
 	<distance>18</distance>
 	<binary>
-		<separation>28.6</separation>
+		<separation unit="arcsec">28.6</separation>
+		<separation unit="AU">515</separation>
 		<positionangle>150</positionangle>
-		<projected>515</projected>
 		<star>
 			<name>83 Leonis B</name>
 			<name>HD 99492</name>

--- a/systems/91 Aquarii.xml
+++ b/systems/91 Aquarii.xml
@@ -4,9 +4,9 @@
 	<declination>-09 05 15</declination>
 	<distance errorminus="0.6" errorplus="0.6">45.9</distance>
 	<binary>
-		<separation>49.4</separation>
+		<separation unit="arcsec">49.4</separation>
+		<separation unit="AU">2267</separation>
 		<positionangle>313</positionangle>
-		<projected>2267</projected>
 		<star>
 			<name>91 Aquarii A</name>
 			<name>91 Aqr A</name>
@@ -45,9 +45,9 @@
 			</planet>
 		</star>
 		<binary>
-			<separation>0.4</separation>
+			<separation unit="arcsec">0.4</separation>
+			<separation unit="AU">18.4</separation>
 			<positionangle>101</positionangle>
-			<projected>18.4</projected>
 			<star>
 				<name>91 Aquarii B</name>
 				<name>91 Aqr B</name>

--- a/systems/Gliese 777.xml
+++ b/systems/Gliese 777.xml
@@ -4,9 +4,9 @@
 	<declination>+29 53 48</declination>
 	<distance>15.89</distance>
 	<binary>
-		<separation>179</separation>
+		<separation unit="arcsec">179</separation>
+		<separation unit="AU">2844</separation>
 		<positionangle>234</positionangle>
-		<projected>2844</projected>
 		<star>
 			<name>Gliese 777 A</name>
 			<name>HD 190360 A</name>

--- a/systems/HD 114729.xml
+++ b/systems/HD 114729.xml
@@ -4,9 +4,9 @@
 	<declination>-31 52 24</declination>
 	<distance>35</distance>
 	<binary>
-		<separation>8.05</separation>
+		<separation unit="arcsec">8.05</separation>
+		<separation unit="AU">282</separation>
 		<positionangle>333</positionangle>
-		<projected>282</projected>
 		<star>
 			<name>HD 114729 A</name>
 			<mass>0.93</mass>

--- a/systems/HD 114762.xml
+++ b/systems/HD 114762.xml
@@ -4,9 +4,9 @@
 	<declination>+17 31 01</declination>
 	<distance>39.46</distance>
 	<binary>
-		<separation>3.26</separation>
+		<separation unit="arcsec">3.26</separation>
+		<separation unit="AU">129</separation>
 		<positionangle>30</positionangle>
-		<projected>129</projected>
 		<star>
 			<name>HD 114762 A</name>
 			<mass>0.84</mass>

--- a/systems/HD 11964.xml
+++ b/systems/HD 11964.xml
@@ -4,9 +4,9 @@
 	<declination>-10 14 32</declination>
 	<distance>33.98</distance>
 	<binary>
-		<separation>29.7</separation>
+		<separation unit="arcsec">29.7</separation>
+		<separation unit="AU">1010</separation>
 		<positionangle>133</positionangle>
-		<projected>1010</projected>
 		<star>
 			<name>HD 11964 A</name>
 			<name>Gliese 81.1 A</name>

--- a/systems/HD 142.xml
+++ b/systems/HD 142.xml
@@ -4,9 +4,9 @@
 	<declination>-49 04 30</declination>
 	<distance>20.6</distance>
 	<binary>
-		<separation>5.4</separation>
+		<separation unit="arcsec">5.4</separation>
+		<separation unit="AU">111</separation>
 		<positionangle>177</positionangle>
-		<projected>111</projected>
 		<star>
 			<name>HD 142 A</name>
 			<mass>1.15</mass>

--- a/systems/HD 142022.xml
+++ b/systems/HD 142022.xml
@@ -4,9 +4,9 @@
 	<declination>-84 13 53</declination>
 	<distance>35.87</distance>
 	<binary>
-		<separation>20.4</separation>
+		<separation unit="arcsec">20.4</separation>
+		<separation unit="AU">732</separation>
 		<positionangle>130</positionangle>
-		<projected>732</projected>
 		<star>
 			<name>HD 142022 A</name>
 			<mass>0.99</mass>

--- a/systems/HD 147513.xml
+++ b/systems/HD 147513.xml
@@ -4,9 +4,9 @@
 	<declination>-39 11 34</declination>
 	<distance>12.9</distance>
 	<binary>
-		<separation>345</separation>
+		<separation unit="arcsec">345</separation>
+		<separation unit="AU">4451</separation>
 		<positionangle>245</positionangle>
-		<projected>4451</projected>
 		<star>
 			<name>HD 147513 A</name>
 			<name>62 G. Scorpii A</name>

--- a/systems/HD 178911.xml
+++ b/systems/HD 178911.xml
@@ -4,9 +4,9 @@
 	<declination>+34 35 59</declination>
 	<distance>46.73</distance>
 	<binary>
-		<separation>16.1</separation>
+		<separation unit="arcsec">16.1</separation>
+		<separation unit="AU">752</separation>
 		<positionangle>82</positionangle>
-		<projected>752</projected>
 		<star>
 			<name>HD 178911 B</name>
 			<name>HR 7272</name>

--- a/systems/HD 188015.xml
+++ b/systems/HD 188015.xml
@@ -4,9 +4,9 @@
 	<declination>+28 06 01</declination>
 	<distance>52.6</distance>
 	<binary>
-		<separation>13</separation>
+		<separation unit="arcsec">13</separation>
+		<separation unit="AU">684</separation>
 		<positionangle>85</positionangle>
-		<projected>684</projected>
 		<star>
 			<name>HD 188015 A</name>
 			<mass>1.09</mass>

--- a/systems/HD 195019.xml
+++ b/systems/HD 195019.xml
@@ -4,9 +4,9 @@
 	<declination>+18 46 12</declination>
 	<distance>37.36</distance>
 	<binary>
-		<separation>3.5</separation>
+		<separation unit="arcsec">3.5</separation>
+		<separation unit="AU">130</separation>
 		<positionangle>330</positionangle>
-		<projected>130</projected>
 		<star>
 			<name>HD 195019 A</name>
 			<mass>1.06</mass>

--- a/systems/HD 196050.xml
+++ b/systems/HD 196050.xml
@@ -4,9 +4,9 @@
 	<declination>-60 38 04</declination>
 	<distance>46.93</distance>
 	<binary>
-		<separation>10.9</separation>
+		<separation unit="arcsec">10.9</separation>
+		<separation unit="AU">511</separation>
 		<positionangle>175</positionangle>
-		<projected>511</projected>
 		<star>
 			<name>HD 196050 A</name>
 			<name>HIP 101806</name>

--- a/systems/HD 213240.xml
+++ b/systems/HD 213240.xml
@@ -4,9 +4,9 @@
 	<declination>-49 25 59</declination>
 	<distance>40.75</distance>
 	<binary>
-		<separation>95.8</separation>
+		<separation unit="arcsec">95.8</separation>
+		<separation unit="AU">3904</separation>
 		<positionangle>127</positionangle>
-		<projected>3904</projected>
 		<star>
 			<name>HD 213240 A</name>
 			<mass>1.22</mass>

--- a/systems/HD 222582.xml
+++ b/systems/HD 222582.xml
@@ -4,9 +4,9 @@
 	<declination>-05 59 08</declination>
 	<distance>42</distance>
 	<binary>
-		<separation>113</separation>
+		<separation unit="arcsec">113</separation>
+		<separation unit="AU">4746</separation>
 		<positionangle>302</positionangle>
-		<projected>4746</projected>
 		<star>
 			<name>HD 222582 A</name>
 			<name>HIP 116906 A</name>

--- a/systems/HD 27442.xml
+++ b/systems/HD 27442.xml
@@ -4,9 +4,9 @@
 	<declination>-59 18 07</declination>
 	<distance>18.1</distance>
 	<binary>
-		<separation>13.8</separation>
+		<separation unit="arcsec">13.8</separation>
+		<separation unit="AU">250</separation>
 		<positionangle>36</positionangle>
-		<projected>250</projected>
 		<star>
 			<name>HD 27442 A</name>
 			<name>Epsilon Reticuli A</name>

--- a/systems/HD 38529.xml
+++ b/systems/HD 38529.xml
@@ -4,9 +4,9 @@
 	<declination>+01 10 05</declination>
 	<distance>39.28</distance>
 	<binary>
-		<separation>284</separation>
+		<separation unit="arcsec">284</separation>
+		<separation unit="AU">11200</separation>
 		<positionangle>305</positionangle>
-		<projected>11200</projected>
 		<star>
 			<name>HD 38529 A</name>
 			<name>138 G. Orionis A</name>

--- a/systems/HD 40979.xml
+++ b/systems/HD 40979.xml
@@ -4,9 +4,9 @@
 	<declination>+44 15 37</declination>
 	<distance>33.3</distance>
 	<binary>
-		<separation>192</separation>
+		<separation unit="arcsec">192</separation>
+		<separation unit="AU">6394</separation>
 		<positionangle>290</positionangle>
-		<projected>6394</projected>
 		<star>
 			<name>HD 40979 A</name>
 			<name>HIP 28767 A</name>

--- a/systems/HD 46375.xml
+++ b/systems/HD 46375.xml
@@ -4,9 +4,9 @@
 	<declination>+05 27 46</declination>
 	<distance>33.4</distance>
 	<binary>
-		<separation>9.4</separation>
+		<separation unit="arcsec">9.4</separation>
+		<separation unit="AU">314</separation>
 		<positionangle>308</positionangle>
-		<projected>314</projected>
 		<star>
 			<name>HD 46375 A</name>
 			<mass>0.91</mass>

--- a/systems/HD 75289.xml
+++ b/systems/HD 75289.xml
@@ -4,9 +4,9 @@
 	<declination>-41 44 12</declination>
 	<distance>28.94</distance>
 	<binary>
-		<separation>21.5</separation>
+		<separation unit="arcsec">21.5</separation>
+		<separation unit="AU">622</separation>
 		<positionangle>78</positionangle>
-		<projected>622</projected>
 		<star>
 			<name>HD 75289 A</name>
 			<mass>1.05</mass>

--- a/systems/HD 80606.xml
+++ b/systems/HD 80606.xml
@@ -4,9 +4,9 @@
 	<declination>+50 36 13</declination>
 	<distance>58.4</distance>
 	<binary>
-		<separation>20.6</separation>
+		<separation unit="arcsec">20.6</separation>
+		<separation unit="AU">1203</separation>
 		<positionangle>269</positionangle>
-		<projected>1203</projected>
 		<star>
 			<name>HD 80606</name>
 			<name>Struve 1341 B</name>

--- a/systems/HD 89744.xml
+++ b/systems/HD 89744.xml
@@ -4,9 +4,9 @@
 	<declination>+41 13 46</declination>
 	<distance>40</distance>
 	<binary>
-		<separation>63.0</separation>
+		<separation unit="arcsec">63.0</separation>
+		<separation unit="AU">2520</separation>
 		<positionangle>48</positionangle>
-		<projected>2520</projected>
 		<star>
 			<name>HD 89744 A</name>
 			<name>HR 4067 A</name>

--- a/systems/Upsilon Andromedae.xml
+++ b/systems/Upsilon Andromedae.xml
@@ -4,9 +4,9 @@
 	<declination>+41 24 38</declination>
 	<distance>13.47</distance>
 	<binary>
-		<separation>52</separation>
+		<separation unit="arcsec">52</separation>
+		<separation unit="AU">700</separation>
 		<positionangle>150</positionangle>
-		<projected>700</projected>
 		<star>
 			<name>Upsilon Andromedae A</name>
 			<name>ups And A</name>


### PR DESCRIPTION
Added binary separation/position angle information from Raghavan et al. (2006).

Projected separations in AU are recalculated using the distance values included in the file.

Three new elements are used to represent these systems:
separation = separation between the components, in arcseconds
positionangle = position angle of the secondary, in degrees
projected = projected separation between the components, in AU

The cleanup.py script is updated to handle the new elements.

The rationale for using the new elements is to maintain a clean separation between systems for which orbital elements are known and those for which they are not: semimajor axis and projected separation are in general two different quantities. The reason to maintain both angular and linear values of the separation is to keep the observational value that is not dependent on distance estimates available.
