### PR TITLE
Added SIMBAD-compatible names to 10 systems.

### DIFF
--- a/systems/2M 044144.xml
+++ b/systems/2M 044144.xml
@@ -1,5 +1,6 @@
 <system>
 	<name>2M 044144</name>
+	<name>2MASS J04414489+2301513</name>
 	<rightascension>04 41 45</rightascension>
 	<declination>+23 01 51</declination>
 	<distance>140</distance>
@@ -8,6 +9,7 @@
 		<spectraltype>M8.5</spectraltype>
 		<planet>
 			<name>2M 044144 b</name>
+			<name>2MASS J04414489+2301513 b</name>
 			<list>Confirmed planets</list>
 			<mass>7.5</mass>
 			<semimajoraxis>15</semimajoraxis>
@@ -16,6 +18,7 @@
 			<discoveryyear>2010</discoveryyear>
 		</planet>
 		<name>2M 044144</name>
+		<name>2MASS J04414489+2301513</name>
 		<temperature>3840.0</temperature>
 	</star>
 </system>

--- a/systems/2M 0746+20.xml
+++ b/systems/2M 0746+20.xml
@@ -1,5 +1,6 @@
 <system>
 	<name>2M 0746+20</name>
+	<name>2MASS J07464256+2000321</name>
 	<rightascension>07 46 43</rightascension>
 	<declination>+20 00 32</declination>
 	<distance>12.21</distance>
@@ -9,6 +10,7 @@
 		<spectraltype>L0/L1.5</spectraltype>
 		<planet>
 			<name>2M 0746+20 b</name>
+			<name>2MASS J07464256+2000321 B</name>
 			<list>Confirmed planets</list>
 			<mass>30</mass>
 			<radius>0.97</radius>
@@ -21,6 +23,7 @@
 			<discoveryyear>2010</discoveryyear>
 		</planet>
 		<name>2M 0746+20</name>
+		<name>2MASS J07464256+2000321 A</name>
 		<temperature>2205.0</temperature>
 	</star>
 	<videolink>http://youtu.be/N0QjGA_fqb4</videolink>

--- a/systems/2M 2140+16.xml
+++ b/systems/2M 2140+16.xml
@@ -1,5 +1,6 @@
 <system>
 	<name>2M 2140+16</name>
+	<name>2MASS J21402931+1625183</name>
 	<rightascension>21 40 29</rightascension>
 	<declination>+16 25 18</declination>
 	<distance>25</distance>
@@ -9,6 +10,7 @@
 		<spectraltype>M8.5/L2</spectraltype>
 		<planet>
 			<name>2M 2140+16 b</name>
+			<name>2MASS J21402931+1625183 b</name>
 			<list>Confirmed planets</list>
 			<mass>20</mass>
 			<radius>0.92</radius>
@@ -21,6 +23,7 @@
 			<discoveryyear>2010</discoveryyear>
 		</planet>
 		<name>2M 2140+16</name>
+		<name>2MASS J21402931+1625183</name>
 		<temperature>2300.0</temperature>
 	</star>
 </system>

--- a/systems/2M 2206-20.xml
+++ b/systems/2M 2206-20.xml
@@ -1,5 +1,6 @@
 <system>
 	<name>2M 2206-20</name>
+	<name>2MASS J22062280-2047058</name>
 	<rightascension>22 06 23</rightascension>
 	<declination>-20 47 06</declination>
 	<distance>26.67</distance>
@@ -9,6 +10,7 @@
 		<spectraltype>M8</spectraltype>
 		<planet>
 			<name>2M 2206-20 b</name>
+			<name>2MASS J22062280-2047058 b</name>
 			<list>Confirmed planets</list>
 			<mass>30</mass>
 			<radius>1.3</radius>
@@ -21,6 +23,7 @@
 			<discoveryyear>2010</discoveryyear>
 		</planet>
 		<name>2M 2206-20</name>
+		<name>2MASS J22062280-2047058</name>
 		<temperature>2350.0</temperature>
 	</star>
 </system>

--- a/systems/2M1207.xml
+++ b/systems/2M1207.xml
@@ -1,5 +1,6 @@
 <system>
 	<name>2M1207</name>
+	<name>2MASS J12073346-3932539</name>
 	<rightascension>12 07 33</rightascension>
 	<declination>-39 32 54</declination>
 	<distance>52.4</distance>
@@ -21,6 +22,7 @@
 			<imagedescription>This image shows the brown dwarf 2M1207 and a planetary companion (lower left). It was the first image of an extrasolar planet and has been published 2004. Credit: ESO.</imagedescription>
 		</planet>
 		<name>2M1207</name>
+		<name>2MASS J12073346-3932539</name>
 		<temperature>2550.0</temperature>
 	</star>
 	<videolink>http://youtu.be/w7Ktw1kytF0</videolink>

--- a/systems/CFBDS 1458.xml
+++ b/systems/CFBDS 1458.xml
@@ -1,5 +1,6 @@
 <system>
 	<name>CFBDS 1458</name>
+	<name>CFBDSIR J145829+101343</name>
 	<rightascension>14 58 29</rightascension>
 	<declination>+10 13 43</declination>
 	<distance>23.1</distance>

--- a/systems/CFBDSIR2149.xml
+++ b/systems/CFBDSIR2149.xml
@@ -1,12 +1,15 @@
 <system>
 	<name>CFBDSIR2149</name>
 	<name>CFBDSIR J214947.2-040308.9</name>
+	<name>CFBDS J214947-040308</name>
 	<rightascension>21 49 47</rightascension>
 	<declination>-04 03 08</declination>
 	<distance>40</distance>
 	<spectraltype>T7/T7.5</spectraltype>
 	<planet>
 		<name>CFBDSIR2149</name>
+		<name>CFBDSIR J214947.2-040308.9</name>
+		<name>CFBDS J214947-040308</name>
 		<list>Confirmed planets</list>
 		<list>Orphan planets</list>
 		<mass>5.5</mass>

--- a/systems/NGC 4349 No 127.xml
+++ b/systems/NGC 4349 No 127.xml
@@ -1,15 +1,18 @@
 <system>
 	<name>NGC 4349 No 127</name>
+	<name>NGC 4349 MMU 127</name>
 	<rightascension>12 24 08</rightascension>
 	<declination>-61 52 18</declination>
 	<distance>2176</distance>
 	<star>
 		<name>NGC 4349 No 127</name>
+		<name>NGC 4349 MMU 127</name>
 		<mass>3.9</mass>
 		<magV>7.4</magV>
 		<planet>
 			<name>NGC 4349 No 127 b</name>
 			<name>NGC 4349 127 b</name>
+			<name>NGC 4349 MMU 127 b</name>
 			<list>Confirmed planets</list>
 			<mass>19.8</mass>
 			<period>677.8</period>

--- a/systems/SAND364.xml
+++ b/systems/SAND364.xml
@@ -1,10 +1,13 @@
 <system>
 	<name>SAND364</name>
+	<name>NGC 2682 SAND 364</name>
 	<rightascension>08 49 57</rightascension>
 	<declination>+11 41 33</declination>
 	<distance errorminus="50" errorplus="50">750</distance>
 	<star>
 		<name>SAND364</name>
+		<name>NGC 2682 SAND 364</name>
+		<name>BD+12 1917</name>
 		<mass errorminus="0.05" errorplus="0.05">1.35</mass>
 		<radius errorminus="0.7" errorplus="0.7">21.8</radius>
 		<temperature errorminus="9" errorplus="9">4284</temperature>
@@ -12,6 +15,8 @@
 		<spectraltype>K3III</spectraltype>
 		<planet>
 			<name>SAND364 b</name>
+			<name>NGC 2682 SAND 364 b</name>
+			<name>BD+12 1917 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.24" errorplus="0.24">1.54</mass>
 			<period errorminus="0.305" errorplus="0.305">121.710</period>

--- a/systems/YBP1514.xml
+++ b/systems/YBP1514.xml
@@ -1,10 +1,12 @@
 <system>
 	<name>YBP1514</name>
+	<name>NGC 2682 YBP 1514</name>
 	<rightascension>08 51 01</rightascension>
 	<declination>+11 53 12</declination>
 	<distance errorminus="50" errorplus="50">750</distance>
 	<star>
 		<name>YBP1514</name>
+		<name>NGC 2682 YBP 1514</name>
 		<mass errorminus="0.01" errorplus="0.01">0.96</mass>
 		<radius errorminus="0.02" errorplus="0.02">0.89</radius>
 		<temperature errorminus="45" errorplus="45">5725</temperature>
@@ -12,6 +14,7 @@
 		<spectraltype>G5V</spectraltype>
 		<planet>
 			<name>YBP1514 b</name>
+			<name>NGC 2682 YBP 1514 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.11" errorplus="0.11">0.4</mass>
 			<period errorminus="0.001" errorplus="0.001">5.118</period>


### PR DESCRIPTION
Some names that work with SIMBAD, though a couple of the open cluster ones will still need a "Cl*" prefix when used in the search.
