### PR TITLE
The accent in "Boötis" is a diaeresis, not an umlaut.

### DIFF
--- a/systems/tau Boo.xml
+++ b/systems/tau Boo.xml
@@ -9,6 +9,7 @@
 		<star>
 			<name>tau Boo A</name>
 			<name>Tau Boötis A</name>
+			<name>Tau Bootis A</name>
 			<name>HD 120136 A</name>
 			<name>GJ 527 A</name>
 			<name>Gliese 527 A</name>
@@ -28,6 +29,7 @@
 			<planet>
 				<name>tau Boo A b</name>
 				<name>Tau Boötis A b</name>
+				<name>Tau Bootis A b</name>
 				<name>HD 120136 A b</name>
 				<name>GJ 527 A b</name>
 				<name>Gliese 527 A b</name>
@@ -53,6 +55,7 @@
 		<star>
 			<name>tau Boo B</name>
 			<name>Tau Boötis B</name>
+			<name>Tau Bootis B</name>
 			<name>HD 120136 B</name>
 			<name>GJ 527 B</name>
 			<name>Gliese 527 B</name>


### PR DESCRIPTION
It does not expand to "oe", rather it marks the fact that the two vowels do not form a diphthong.
