### PR TITLE
corrected RA, DE

### DIFF
--- a/systems/HD 219415.xml
+++ b/systems/HD 219415.xml
@@ -1,7 +1,7 @@
 <system>
 	<name>HD 219415</name>
-	<rightascension>01 43 40</rightascension>
-	<declination>+21 00 19</declination>
+	<rightascension>23 14 53.82</rightascension>
+	<declination>+56 43 49.15</declination>
 	<star>
 		<mass>1.0</mass>
 		<radius>2.9</radius>


### PR DESCRIPTION
RA and DE from BD+20 274 were placed here. Updated them to values of HD 219415
http://arxiv.org/pdf/1207.0488.pdf : PLANETS AROUND THE K-GIANTS BD+20 274 AND HD 219415
http://simbad.u-strasbg.fr/simbad/sim-id?Ident=hd+219415&NbIdent=1&Radius=2&Radius.unit=arcmin&submit=submit+id
