### PR TITLE
Updated Gliese 676.

### DIFF
--- a/systems/Gliese 676.xml
+++ b/systems/Gliese 676.xml
@@ -23,42 +23,55 @@
 				<name>Gliese 676 A d</name>
 				<name>GJ 676 A d</name>
 				<list>Confirmed planets</list>
-				<mass>0.014</mass>
-				<period>3.6000</period>
-				<semimajoraxis>0.0413</semimajoraxis>
-				<eccentricity>0.15</eccentricity>
+				<mass errorminus="0.002" errorplus="0.002">0.014</mass>
+				<period errorminus="0.0008" errorplus="0.0008">3.6000</period>
+				<semimajoraxis errorminus="0.0014" errorplus="0.0014">0.0413</semimajoraxis>
+				<eccentricity errorminus="0.09" errorplus="0.09">0.15</eccentricity>
 				<description>The star system Gliese 676 is located in the constellation Ara. This  planet was confirmed using a Bayesian probability analysis. It is a small Super-Earth.</description>
 				<discoverymethod>RV</discoverymethod>
 				<lastupdate>12/12/05</lastupdate>
-				<discoveryyear>2011</discoveryyear>
+				<discoveryyear>2012</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 			</planet>
 			<planet>
 				<name>Gliese 676 A e</name>
 				<name>GJ 676 A e</name>
 				<list>Confirmed planets</list>
-				<mass>0.187</mass>
-				<period>35.37</period>
-				<semimajoraxis>0.187</semimajoraxis>
-				<eccentricity>0.24</eccentricity>
+				<mass errorminus="0.005" errorplus="0.005">0.036</mass>
+				<period errorminus="0.07" errorplus="0.07">35.37</period>
+				<semimajoraxis errorminus="0.007" errorplus="0.007">0.187</semimajoraxis>
+				<eccentricity errorminus="0.12" errorplus="0.12">0.24</eccentricity>
 				<description>The star system Gliese 676 is located in the constellation Ara. This  planet was confirmed using a Bayesian probability analysis. It has a false alarme probability of less than one percent.</description>
 				<discoverymethod>RV</discoverymethod>
 				<lastupdate>12/12/05</lastupdate>
-				<discoveryyear>2011</discoveryyear>
+				<discoveryyear>2012</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 			</planet>
 			<planet>
 				<name>Gliese 676 A b</name>
 				<name>GJ 676 A b</name>
 				<list>Confirmed planets</list>
-				<mass>4.95</mass>
-				<period>1050.3</period>
-				<semimajoraxis>1.80</semimajoraxis>
-				<eccentricity>0.328</eccentricity>
+				<mass errorminus="0.31" errorplus="0.31">4.95</mass>
+				<period errorminus="1.2" errorplus="1.2">1050.3</period>
+				<semimajoraxis errorminus="0.07" errorplus="0.07">1.80</semimajoraxis>
+				<eccentricity errorminus="0.004" errorplus="0.004">0.328</eccentricity>
 				<description>This gas giant was found in 2009 and announced in 2011. At that time there were strong indications for more planets but more data was needed to confirm them.</description>
 				<discoverymethod>RV</discoverymethod>
 				<lastupdate>12/12/05</lastupdate>
-				<discoveryyear>2009</discoveryyear>
+				<discoveryyear>2011</discoveryyear>
+				<list>Planets in binary systems, S-type</list>
+			</planet>
+			<planet>
+				<name>Gliese 676 A c</name>
+				<name>GJ 676 A c</name>
+				<list>Controversial</list>
+				<mass>3.0</mass>
+				<period>4400</period>
+				<semimajoraxis>5.2</semimajoraxis>
+				<eccentricity>0.2</eccentricity>
+				<description>This companion is inferred from a curvature in the radial velocity residuals. Its nature is currently unclear.</description>
+				<discoverymethod>RV</discoverymethod>
+				<discoveryyear>2011</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 			</planet>
 		</star>


### PR DESCRIPTION
- Added Gliese 676 Ac (RV trend). Related issue: #230
- Updated discovery dates to publication dates of relevant papers.
- Added error bars.
- Fixed mass of Gliese 676 Ae.

Planet values from: [Anglada-Escudé & Tuomi (2012)](http://adsabs.harvard.edu/abs/2012A%26A...548A..58A)

Discovery information for Gliese 676 Ab, c: [Forveille et al. (2011)](http://adsabs.harvard.edu/abs/2011A&A...526A.141F)
