### PR TITLE
Moved Fomalhaut b to "Controversial" list.

### DIFF
--- a/systems/Fomalhaut.xml
+++ b/systems/Fomalhaut.xml
@@ -52,15 +52,14 @@
 					<name>IRAS 22549-2953 b</name>
 					<name>alf PsA b</name>
 					<name>24 PsA b</name>
-					<list>Confirmed planets</list>
-					<mass>3</mass>
+					<list>Controversial</list>
 					<period>320000</period>
 					<semimajoraxis errorminus="68" errorplus="68">177</semimajoraxis>
 					<eccentricity errorminus="0.1" errorplus="0.1">0.8</eccentricity>
 					<inclination errorminus="14" errorplus="14">305</inclination>
 					<periastron errorminus="25" errorplus="25">26</periastron>
 					<ascendingnode errorminus="13" errorplus="13">152</ascendingnode>
-					<description>Formalhaut is one of the brightest stars in the night sky and located in the constellation Piscis Austrinus. It is a young star with a debris disk. In 2008 astronomers reported the discovery of a planet orbiting the star within the debris disk. Images from the Hubble space telescope show motion consistent with a Keplerian orbit that crossed the disk. However, there are still debates about where the observed emission is coming from.</description>
+					<description>Formalhaut is one of the brightest stars in the night sky and located in the constellation Piscis Austrinus. It is a young star with a debris disk. In 2008 astronomers reported the discovery of a planet orbiting the star within the debris disk. Images from the Hubble space telescope show motion consistent with a Keplerian orbit that crossed the disk. However, there are still debates about where the observed emission is coming from. The object may be an isolated dust cloud or even a background neutron star.</description>
 					<discoverymethod>imaging</discoverymethod>
 					<image>Fomalhaut</image>
 					<imagedescription>This false-color composite image, taken with the Hubble Space Telescope, reveals the orbital motion of the planet Fomalhaut b. The planet will appear to cross a vast belt of debris around the star roughly 20 years from now. If the planet's orbit lies in the same plane with the belt, icy and rocky debris in the belt could crash into the planet's atmosphere and produce various phenomena. The black circle at the center of the image blocks out the light from the bright star, allowing reflected light from the belt and planet to be photographed. 


### PR DESCRIPTION
As this object may be a [dust cloud not associated with a planet](http://arxiv.org/abs/1412.1129) or even possibly a [background neutron star](http://arxiv.org/abs/1501.07083), I think this one should be moved to the "Controversial" list. I've also removed the mass estimate that was based on the assumption that the optical emission was coming from the surface of a gas giant planet, which is inconsistent with the ring-crossing orbit (if it is part of the system).