### PR TITLE
Added K2 IDs to WASP-28 (K2-1) and HIP 116454 (K2-2)

### DIFF
--- a/systems/HIP 116454.xml
+++ b/systems/HIP 116454.xml
@@ -5,7 +5,8 @@
 	<distance errorminus="5.4" errorplus="5.4">55.2</distance>
 	<star>
 		<name>HIP 116454</name>
-		<name>BD-00 45 34</name>
+		<name>K2-2</name>
+		<name>BD-00 4534</name>
 		<name>2MASS J23354927+0026436</name>
 		<name>PPM 174245</name>
 		<name>TYC 585-774-1</name>
@@ -25,7 +26,8 @@
 		<spectraltype>K0</spectraltype>
 		<planet>
 			<name>HIP 116454 b</name>
-			<name>BD-00 45 34 b</name>
+			<name>K2-2 b</name>
+			<name>BD-00 4534 b</name>
 			<name>2MASS J23354927+0026436 b</name>
 			<name>PPM 174245 b</name>
 			<name>TYC 585-774-1 b</name>

--- a/systems/WASP-28.xml
+++ b/systems/WASP-28.xml
@@ -5,6 +5,8 @@
 	<distance errorminus="70" errorplus="70">410</distance>
 	<star>
 		<name>WASP-28</name>
+		<name>2MASS J23342787-0134482</name>
+		<name>K2-1</name>
 		<temperature errorminus="140" errorplus="140">6150</temperature>
 		<mass errorminus="0.05" errorplus="0.05">1.021</mass>
 		<radius errorminus="0.031" errorplus="0.031">1.094</radius>
@@ -20,6 +22,7 @@
 		<planet>
 			<name>WASP-28 b</name>
 			<name>2MASS J23342787-0134482 b</name>
+			<name>K2-1 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.043" errorplus="0.043">0.907</mass>
 			<radius errorminus="0.042" errorplus="0.042">1.213</radius>


### PR DESCRIPTION
[WASP-28](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=WASP+28+b&type=CONFIRMED_PLANET) and [HIP 116454](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=HIP+116454+b&type=CONFIRMED_PLANET) have received IDs from the K2 mission. See also http://exoplanetarchive.ipac.caltech.edu/docs/K2Numbers.html