### PR TITLE
Update Upsilon Andromedae

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following table shows all the possible tags in the Open Exoplanet Catalogue.
 | `eccentricity` 	| `binary`, `planet` | Eccentricity  | |
 | `periastron` 	| `binary`, `planet` | Longitude of periastron | degree  |
 | `longitude` 	| `binary`, `planet` | Mean longitude at a given Epoch (same for all planets in one system) | degree  |
+| `meananomaly`	| `binary`, `planet` | Mean anomaly at a given Epoch (same for all planets in one system) | degree  |
 | `ascendingnode` 	| `binary`, `planet` | Longitude of the ascending node | degree  |
 | `inclination` 	| `binary`, `planet` | Inclination of the orbit | degree  |
 | `epoch` | `system` | Epoch for the orbital elements | BJD |

--- a/cleanup.py
+++ b/cleanup.py
@@ -85,7 +85,8 @@ validtags = [
     "longitude", "imagedescription", "image", "age", "declination", "rightascension",
     "metallicity", "inclination", "spectraltype", "binary", "planet", "periastron", "star",
     "mass", "eccentricity", "radius", "temperature", "videolink", "transittime", 
-    "spinorbitalignment", "istransiting", "separation", "positionangle", "periastrontime"]
+    "spinorbitalignment", "istransiting", "separation", "positionangle", "periastrontime",
+    "meananomaly"]
 validattributes = [
     "error",
     "errorplus",
@@ -108,7 +109,7 @@ tagsallowmultiple = ["list", "name", "planet", "star", "binary", "separation"]
 numerictags = ["mass", "radius", "ascnedingnode", "discoveryyear", "semimajoraxis", "period",
     "magV", "magJ", "magH", "magR", "magB", "magK", "magI", "magU", "distance", "longitude", "age",
     "metallicity", "inclination", "periastron", "eccentricity", "temperature", "transittime",
-    "spinorbitalignment", "separation", "positionangle", "periastrontime"]
+    "spinorbitalignment", "separation", "positionangle", "periastrontime", "meananomaly"]
 numericattributes = ["error", "errorplus", "errorminus", "upperlimit", "lowerlimit"]
 nonzeroattributes = ["error", "errorplus", "errorminus"]
 

--- a/oec.xsd
+++ b/oec.xsd
@@ -37,6 +37,7 @@
 				<xs:element name="longitude" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="ascendingnode" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="inclination" type="number" minOccurs="0" maxOccurs="1"/>
+				<xs:element name="meananomaly" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="period" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="transittime" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="periastrontime" type="number" minOccurs="0" maxOccurs="1"/>
@@ -101,6 +102,7 @@
 				<xs:element name="eccentricity" type="number"/>
 				<xs:element name="periastron" type="number"/>
 				<xs:element name="longitude" type="number"/>
+				<xs:element name="meananomaly" type="number"/>
 				<xs:element name="ascendingnode" type="number"/>
 				<xs:element name="inclination" type="number"/>
 				<xs:element name="period" type="number"/>

--- a/systems/Upsilon Andromedae.xml
+++ b/systems/Upsilon Andromedae.xml
@@ -27,14 +27,17 @@
 				<name>ups And A b</name>
 				<name>ups And b</name>
 				<list>Confirmed planets</list>
-				<mass>0.69</mass>
-				<period>4.617136</period>
-				<semimajoraxis>0.059</semimajoraxis>
-				<eccentricity>0.013</eccentricity>
-				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 4 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
-				<inclination>30</inclination>
+				<mass>1.78</mass>
+				<period>4.61716</period>
+				<semimajoraxis>0.059408</semimajoraxis>
+				<eccentricity>0.011769</eccentricity>
+				<inclination>22.99</inclination>
+				<periastron>51.14</periastron>
+				<ascendingnode>7.28</ascendingnode>
+				<meananomaly>103.53</meananomaly>
+				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 3 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
 				<discoverymethod>RV</discoverymethod>
-				<lastupdate>12/12/08</lastupdate>
+				<lastupdate>15/03/16</lastupdate>
 				<discoveryyear>1996</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 				<temperature>1440.1</temperature>
@@ -44,14 +47,17 @@
 				<name>ups And A c</name>
 				<name>ups And c</name>
 				<list>Confirmed planets</list>
-				<mass>14.57</mass>
-				<period>237.7</period>
-				<semimajoraxis>0.861</semimajoraxis>
-				<eccentricity>0.24</eccentricity>
-				<inclination>8</inclination>
+				<mass>10.78</mass>
+				<period>241.02</period>
+				<semimajoraxis>0.831580</semimajoraxis>
+				<eccentricity>0.247042</eccentricity>
+				<inclination>10.09</inclination>
+				<periastron>248.74</periastron>
+				<ascendingnode>256.34</ascendingnode>
+				<meananomaly>154.47</meananomaly>
 				<discoverymethod>RV</discoverymethod>
-				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 4 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
-				<lastupdate>12/12/08</lastupdate>
+				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 3 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
+				<lastupdate>15/03/16</lastupdate>
 				<discoveryyear>1999</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 				<temperature>375.6</temperature>
@@ -61,14 +67,17 @@
 				<name>ups And A d</name>
 				<name>ups And d</name>
 				<list>Confirmed planets</list>
-				<mass>10.19</mass>
-				<period>1302.61</period>
-				<semimajoraxis>2.55</semimajoraxis>
-				<eccentricity>0.274</eccentricity>
-				<inclination>24</inclination>
+				<mass>8.86</mass>
+				<period>1282.57</period>
+				<semimajoraxis>2.533539</semimajoraxis>
+				<eccentricity>0.249090</eccentricity>
+				<inclination>28.30</inclination>
+				<periastron>253.27</periastron>
+				<ascendingnode>9.97</ascendingnode>
+				<meananomaly>82.57</meananomaly>
 				<discoverymethod>RV</discoverymethod>
-				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 4 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
-				<lastupdate>12/12/08</lastupdate>
+				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 3 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
+				<lastupdate>15/03/16</lastupdate>
 				<discoveryyear>1999</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 				<temperature>218.0</temperature>
@@ -77,14 +86,14 @@
 				<name>Upsilon Andromedae A e</name>
 				<name>ups And A e</name>
 				<name>ups And e</name>
-				<list>Confirmed planets</list>
+				<list>Controversial</list>
 				<mass>1.059</mass>
 				<period>3848.86</period>
 				<semimajoraxis>5.2456</semimajoraxis>
 				<eccentricity>0.00536</eccentricity>
 				<discoverymethod>RV</discoverymethod>
-				<description>The binary star Upsilon Andromedae is only 40 light years away from Earth. The system hosts at least 4 jovian planets. It was the first multiple planet system to be discovered around a main sequence star.</description>
-				<lastupdate>12/12/08</lastupdate>
+				<description>The detection of the fourth planet in the Upsilon Andromedae system has been questioned due to the presence of an unaccounted-for instrumental shift in earlier reductions of the radial velocity data from the Lick observatory.</description>
+				<lastupdate>15/03/16</lastupdate>
 				<discoveryyear>2010</discoveryyear>
 				<list>Planets in binary systems, S-type</list>
 				<temperature>150.6</temperature>


### PR DESCRIPTION
Added the meananomaly tag to the cleanup script, schema and README

Updated the Upsilon Andromedae system to the orbital solution PRO2 from [Deitrick et al. (2015)](http://adsabs.harvard.edu/abs/2015ApJ...798...46D)
The solution PRO1 was not used due to the difficulty of reconciling this solution with the phase curve data for planet b.

Closes #406