### PR TITLE
Update Kepler-122

### DIFF
--- a/systems/Kepler-122.xml
+++ b/systems/Kepler-122.xml
@@ -20,6 +20,7 @@
 			<name>KOI-232 c</name>
 			<name>KOI-232.01</name>
 			<name>KIC 4833421 c</name>
+			<name>KIC 4833421.01</name>
 			<radius errorminus="0.01458" errorplus="0.10571">0.53493</radius>
 			<period errorminus="0.000009" errorplus="0.000009">12.465988</period>
 			<transittime errorminus="0.0004700" errorplus="0.0004700">2454967.0029100</transittime>
@@ -35,6 +36,7 @@
 			<name>KOI-232 b</name>
 			<name>KOI-232.02</name>
 			<name>KIC 4833421 b</name>
+			<name>KIC 4833421.02</name>
 			<radius errorminus="0.04192" errorplus="0.04192">0.21324</radius>
 			<period errorminus="0.000016" errorplus="0.000016">5.766193</period>
 			<transittime errorminus="0.0017300" errorplus="0.0017300">2454967.0148800</transittime>
@@ -50,6 +52,7 @@
 			<name>KOI-232 d</name>
 			<name>KOI-232.03</name>
 			<name>KIC 4833421 d</name>
+			<name>KIC 4833421.03</name>
 			<radius errorminus="0.04010" errorplus="0.04010">0.20049</radius>
 			<period errorminus="0.000164" errorplus="0.000164">21.587475</period>
 			<transittime errorminus="0.0037900" errorplus="0.0037900">2454975.9728700</transittime>
@@ -65,6 +68,7 @@
 			<name>KOI-232 e</name>
 			<name>KOI-232.04</name>
 			<name>KIC 4833421 e</name>
+			<name>KIC 4833421.04</name>
 			<radius errorminus="0.04921" errorplus="0.04921">0.23694</radius>
 			<period errorminus="0.000390" errorplus="0.000390">37.993273</period>
 			<transittime errorminus="0.0057900" errorplus="0.0057900">2454996.0155300</transittime>

--- a/systems/Kepler-122.xml
+++ b/systems/Kepler-122.xml
@@ -13,16 +13,15 @@
 		<name>KOI-232</name>
 		<name>KIC 4833421</name>
 		<temperature errorminus="37" errorplus="137">6050</temperature>
-		<radius errorminus=".239" errorplus="0.239">1.216</radius>
+		<radius errorminus="0.239" errorplus="0.239">1.216</radius>
 		<mass errorminus="0.1000" errorplus="0.1000">1.0700</mass>
 		<planet>
 			<name>Kepler-122 c</name>
 			<name>KOI-232 c</name>
 			<name>KOI-232.01</name>
 			<name>KIC 4833421 c</name>
-			<name>KIC 4833421.01</name>
 			<radius errorminus="0.01458" errorplus="0.10571">0.53493</radius>
-			<period errorminus=".000009" errorplus="0.000009">12.465988</period>
+			<period errorminus="0.000009" errorplus="0.000009">12.465988</period>
 			<transittime errorminus="0.0004700" errorplus="0.0004700">2454967.0029100</transittime>
 			<list>Confirmed planets</list>
 			<description>Kepler-122 c has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-122 c are still unknown, the object is highly unlikely to be a false positive.</description>
@@ -36,9 +35,8 @@
 			<name>KOI-232 b</name>
 			<name>KOI-232.02</name>
 			<name>KIC 4833421 b</name>
-			<name>KIC 4833421.02</name>
 			<radius errorminus="0.04192" errorplus="0.04192">0.21324</radius>
-			<period errorminus=".000016" errorplus="0.000016">5.766193</period>
+			<period errorminus="0.000016" errorplus="0.000016">5.766193</period>
 			<transittime errorminus="0.0017300" errorplus="0.0017300">2454967.0148800</transittime>
 			<list>Confirmed planets</list>
 			<description>Kepler-122 b has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-122 b are still unknown, the object is highly unlikely to be a false positive.</description>
@@ -52,9 +50,8 @@
 			<name>KOI-232 d</name>
 			<name>KOI-232.03</name>
 			<name>KIC 4833421 d</name>
-			<name>KIC 4833421.03</name>
 			<radius errorminus="0.04010" errorplus="0.04010">0.20049</radius>
-			<period errorminus=".000164" errorplus="0.000164">21.587475</period>
+			<period errorminus="0.000164" errorplus="0.000164">21.587475</period>
 			<transittime errorminus="0.0037900" errorplus="0.0037900">2454975.9728700</transittime>
 			<list>Confirmed planets</list>
 			<description>Kepler-122 d has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-122 d are still unknown, the object is highly unlikely to be a false positive.</description>
@@ -68,15 +65,29 @@
 			<name>KOI-232 e</name>
 			<name>KOI-232.04</name>
 			<name>KIC 4833421 e</name>
-			<name>KIC 4833421.04</name>
 			<radius errorminus="0.04921" errorplus="0.04921">0.23694</radius>
-			<period errorminus=".000390" errorplus="0.000390">37.993273</period>
+			<period errorminus="0.000390" errorplus="0.000390">37.993273</period>
 			<transittime errorminus="0.0057900" errorplus="0.0057900">2454996.0155300</transittime>
 			<list>Confirmed planets</list>
-			<description>Kepler-122 e has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-122 e are still unknown, the object is highly unlikely to be a false positive.</description>
+			<description>Kepler-122 e has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-122 e are still unknown, the object has been confirmed by transit timing variations.</description>
 			<discoveryyear>2014</discoveryyear>
 			<lastupdate>14/02/26</lastupdate>
 			<discoverymethod>transit</discoverymethod>
+			<istransiting>1</istransiting>
+		</planet>
+		<planet>
+			<name>Kepler-122 f</name>
+			<name>KOI-232 f</name>
+			<name>KOI-232.05</name>
+			<name>KIC 4833421 f</name>
+			<radius errorminus="0.014" errorplus="0.053">0.156</radius>
+			<period>56.268</period>
+			<transittime errorminus="0.00546" errorplus="0.00546">2454997.22391</transittime>
+			<list>Confirmed planets</list>
+			<description>Kepler-122 f was confirmed by transit timing variations.</description>
+			<discoverymethod>transit</discoverymethod>
+			<discoveryyear>2014</discoveryyear>
+			<lastupdate>15/03/18</lastupdate>
 			<istransiting>1</istransiting>
 		</planet>
 	</star>


### PR DESCRIPTION
Added planet Kepler-122 f
Removed KIC nnnnn.nn designations (not in actual use)

Hadden & Lithwick (2014) http://adsabs.harvard.edu/abs/2014ApJ...787...80H
Additional data from NASA Kepler Objects of Interest cumulative table.
Additional data from NASA confirmed planets overview.