### PR TITLE
Update Kepler-338

### DIFF
--- a/systems/Kepler-338.xml
+++ b/systems/Kepler-338.xml
@@ -15,21 +15,21 @@
 		<name>KOI-1930</name>
 		<name>KIC 5511081</name>
 		<temperature errorminus="7" errorplus="77">5923</temperature>
-		<radius errorminus=".082" errorplus="0.082">1.735</radius>
+		<radius errorminus="0.082" errorplus="0.082">1.735</radius>
 		<mass errorminus="0.0720" errorplus="0.0720">1.1010</mass>
 		<planet>
 			<name>Kepler-338 b</name>
 			<name>KOI-1930 b</name>
 			<name>KOI-1930.01</name>
 			<name>KIC 5511081 b</name>
-			<name>KIC 5511081.01</name>
 			<radius errorminus="0.01185" errorplus="0.01185">0.22236</radius>
-			<period errorminus=".000059" errorplus="0.000059">13.726976</period>
+			<mass errorminus="0.0663" errorplus="0.0761">0.0963</mass>
+			<period errorminus="0.000059" errorplus="0.000059">13.726976</period>
 			<transittime errorminus="0.0024700" errorplus="0.0024700">2454971.7483300</transittime>
 			<list>Confirmed planets</list>
 			<description>Kepler-338 b has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-338 b are still unknown, the object is highly unlikely to be a false positive.</description>
 			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/26</lastupdate>
+			<lastupdate>15/03/18</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
 		</planet>
@@ -38,9 +38,8 @@
 			<name>KOI-1930 c</name>
 			<name>KOI-1930.02</name>
 			<name>KIC 5511081 c</name>
-			<name>KIC 5511081.02</name>
 			<radius errorminus="0.01094" errorplus="0.01094">0.21324</radius>
-			<period errorminus=".000158" errorplus="0.000158">24.310856</period>
+			<period errorminus="0.000158" errorplus="0.000158">24.310856</period>
 			<transittime errorminus="0.0039700" errorplus="0.0039700">2454970.0414700</transittime>
 			<list>Confirmed planets</list>
 			<description>Kepler-338 c has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-338 c are still unknown, the object is highly unlikely to be a false positive.</description>
@@ -54,14 +53,29 @@
 			<name>KOI-1930 d</name>
 			<name>KOI-1930.03</name>
 			<name>KIC 5511081 d</name>
-			<name>KIC 5511081.03</name>
 			<radius errorminus="0.02552" errorplus="0.02552">0.27339</radius>
-			<period errorminus=".000368" errorplus="0.000368">44.431014</period>
+			<period errorminus="0.000368" errorplus="0.000368">44.431014</period>
 			<transittime errorminus="0.0048000" errorplus="0.0048000">2454976.5419800</transittime>
 			<list>Confirmed planets</list>
 			<description>Kepler-338 d has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-338 d are still unknown, the object is highly unlikely to be a false positive.</description>
 			<discoveryyear>2014</discoveryyear>
 			<lastupdate>14/02/26</lastupdate>
+			<discoverymethod>transit</discoverymethod>
+			<istransiting>1</istransiting>
+		</planet>
+		<planet>
+			<name>Kepler-338 e</name>
+			<name>KOI-1930 e</name>
+			<name>KOI-1930.04</name>
+			<name>KIC 5511081 e</name>
+			<radius errorminus="0.006" errorplus="0.006">0.139</radius>
+			<mass errorminus="0.020" errorplus="0.023">0.027</mass>
+			<period>9.341</period>
+			<transittime errorminus="0.00453" errorplus="0.00453">2454965.38637</transittime>
+			<list>Confirmed planets</list>
+			<description>Kepler-338 e was confirmed by transit timing variations.</description>
+			<discoveryyear>2014</discoveryyear>
+			<lastupdate>15/03/18</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
 		</planet>

--- a/systems/Kepler-338.xml
+++ b/systems/Kepler-338.xml
@@ -22,6 +22,7 @@
 			<name>KOI-1930 b</name>
 			<name>KOI-1930.01</name>
 			<name>KIC 5511081 b</name>
+			<name>KIC 5511081.01</name>
 			<radius errorminus="0.01185" errorplus="0.01185">0.22236</radius>
 			<mass errorminus="0.0663" errorplus="0.0761">0.0963</mass>
 			<period errorminus="0.000059" errorplus="0.000059">13.726976</period>
@@ -38,6 +39,7 @@
 			<name>KOI-1930 c</name>
 			<name>KOI-1930.02</name>
 			<name>KIC 5511081 c</name>
+			<name>KIC 5511081.02</name>
 			<radius errorminus="0.01094" errorplus="0.01094">0.21324</radius>
 			<period errorminus="0.000158" errorplus="0.000158">24.310856</period>
 			<transittime errorminus="0.0039700" errorplus="0.0039700">2454970.0414700</transittime>
@@ -53,6 +55,7 @@
 			<name>KOI-1930 d</name>
 			<name>KOI-1930.03</name>
 			<name>KIC 5511081 d</name>
+			<name>KIC 5511081.03</name>
 			<radius errorminus="0.02552" errorplus="0.02552">0.27339</radius>
 			<period errorminus="0.000368" errorplus="0.000368">44.431014</period>
 			<transittime errorminus="0.0048000" errorplus="0.0048000">2454976.5419800</transittime>


### PR DESCRIPTION
Added planet Kepler-338 e
Removed KIC nnnnn.nn designations (not in actual use)

Hadden & Lithwick (2014) http://adsabs.harvard.edu/abs/2014ApJ...787...80H
Additional data from NASA Kepler Objects of Interest cumulative table.
Additional data from NASA confirmed planets overview.