### PR TITLE
Add missing Kepler/KOI/KIC designations.

### DIFF
--- a/systems/HAT-P-11.xml
+++ b/systems/HAT-P-11.xml
@@ -4,6 +4,10 @@
 	<declination>+48 04 51</declination>
 	<distance>38</distance>
 	<star>
+		<name>HAT-P-11</name>
+		<name>Kepler-3</name>
+		<name>KOI-3</name>
+		<name>KIC 10748390</name>
 		<mass>0.81</mass>
 		<radius>0.75</radius>
 		<magV errorminus="0.02" errorplus="0.02">9.47</magV>
@@ -23,6 +27,7 @@
 			<name>2MASS J19505021+4804508 b</name>
 			<name>Kepler-3 b</name>
 			<name>KIC 10748390 b</name>
+			<name>KOI-3.01</name>
 			<name>KOI-3 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.081</mass>
@@ -39,7 +44,6 @@
 			<transittime errorminus="0.00032" errorplus="0.00032" unit="BJD">2454605.89132</transittime>
 			<istransiting>1</istransiting>
 		</planet>
-		<name>HAT-P-11</name>
 		<temperature>4780.0</temperature>
 	</star>
 </system>

--- a/systems/HAT-P-7.xml
+++ b/systems/HAT-P-7.xml
@@ -29,6 +29,7 @@
 				<name>BD+47 2846 b</name>
 				<name>KIC 10666592 b</name>
 				<name>Kepler-2 b</name>
+				<name>KOI-2.01</name>
 				<name>KOI-2 b</name>
 				<list>Confirmed planets</list>
 				<mass>1.709</mass>

--- a/systems/KIC 10905746.xml
+++ b/systems/KIC 10905746.xml
@@ -10,6 +10,8 @@
 		<metallicity>-0.23</metallicity>
 		<planet>
 			<name>KIC 10905746 b</name>
+			<name>KOI-1725.01</name>
+			<name>KOI-1725 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.237</radius>
 			<period>9.8844</period>
@@ -23,5 +25,6 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>KIC 10905746</name>
+		<name>KOI-1725</name>
 	</star>
 </system>

--- a/systems/KIC 6185331.xml
+++ b/systems/KIC 6185331.xml
@@ -14,6 +14,8 @@
 		<metallicity>0.11</metallicity>
 		<planet>
 			<name>KIC 6185331 b</name>
+			<name>KOI-1727.01</name>
+			<name>KOI-1727 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.72</radius>
 			<period>49.76971</period>
@@ -27,5 +29,6 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>KIC 6185331</name>
+		<name>KOI-1727</name>
 	</star>
 </system>

--- a/systems/KOI-1299.xml
+++ b/systems/KOI-1299.xml
@@ -72,6 +72,8 @@
 		</star>
 		<star>
 			<name>KOI-1299 B</name>
+			<name>Kepler-432 B</name>
+			<name>KIC 10864656 B</name>
 			<mass>0.52</mass>
 			<temperature>3660</temperature>
 		</star>

--- a/systems/KOI-142.xml
+++ b/systems/KOI-142.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>KOI-142</name>
 		<name>Kepler-88</name>
+		<name>KIC 5446285</name>
 		<magJ errorminus="0.020" errorplus="0.020">11.882</magJ>
 		<magH errorminus="0.019" errorplus="0.019">11.517</magH>
 		<magK errorminus="0.019" errorplus="0.019">11.454</magK>
@@ -17,7 +18,9 @@
 		<spectraltype>B</spectraltype>
 		<planet>
 			<name>KOI-142 b</name>
+			<name>KOI-142.01</name>
 			<name>Kepler-88 b</name>
+			<name>KIC 5446285 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.026" errorplus="0.0347">0.37647</radius>
 			<period errorminus="6.4e-05" errorplus="0.00143">10.9542</period>
@@ -39,6 +42,7 @@
 		<planet>
 			<name>KOI-142 c</name>
 			<name>Kepler-88 c</name>
+			<name>KIC 5446285 c</name>
 			<list>Confirmed planets</list>
 			<period errorminus="0.25" errorplus="0.25">22.1</period>
 			<mass errorminus="0.32" errorplus="0.16">0.76</mass>

--- a/systems/KOI-1612.xml
+++ b/systems/KOI-1612.xml
@@ -20,7 +20,9 @@
 		<magK errorminus="0.018" errorplus="0.018">7.486</magK>
 		<planet>
 			<name>KOI-1612.01</name>
+			<name>KOI-1612 b</name>
 			<name>Kepler-408 b</name>
+			<name>KIC 10963065 b</name>
 			<name>HD 176693 b</name>
 			<list>Confirmed planets</list>
 			<period>2.46502</period>

--- a/systems/KOI-1843.xml
+++ b/systems/KOI-1843.xml
@@ -6,6 +6,7 @@
 		<magH errorminus="0.022" errorplus="0.022">11.279</magH>
 		<magK errorminus="0.017" errorplus="0.017">11.056</magK>
 		<name>KOI-1843</name>
+		<name>KIC 5080636</name>
 		<mass errorminus="0.08" errorplus="0.05">0.46</mass>
 		<radius errorminus="0.05" errorplus="0.05">0.45</radius>
 		<temperature errorminus="65" errorplus="65">3584</temperature>

--- a/systems/KOI-206.xml
+++ b/systems/KOI-206.xml
@@ -21,6 +21,7 @@
 		<temperature errorminus="140" errorplus="140">6340</temperature>
 		<planet>
 			<name>KOI-206 b</name>
+			<name>KOI-206.01</name>
 			<name>Kepler-433 b</name>
 			<name>KIC 5728139 b</name>
 			<name>2MASS J19502247+4058381 b</name>

--- a/systems/KOI-423.xml
+++ b/systems/KOI-423.xml
@@ -23,6 +23,7 @@
 		<age errorminus="0.7" errorplus="0.9">1.0</age>
 		<planet>
 			<name>KOI-423 b</name>
+			<name>KOI-423.01</name>
 			<name>Kepler-39 b</name>
 			<name>KIC 9478990 b</name>
 			<list>Confirmed planets</list>

--- a/systems/KOI-428.xml
+++ b/systems/KOI-428.xml
@@ -17,6 +17,7 @@
 		<spectraltype>F5IV</spectraltype>
 		<planet>
 			<name>KOI-428 b</name>
+			<name>KOI-428.01</name>
 			<name>KIC 10418224 b</name>
 			<name>Kepler-40 b</name>
 			<name>2MASS J19471528+4731357 b</name>
@@ -34,5 +35,7 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>KOI-428</name>
+		<name>KIC 10418224</name>
+		<name>Kepler-40</name>
 	</star>
 </system>

--- a/systems/KOI-55.xml
+++ b/systems/KOI-55.xml
@@ -16,6 +16,9 @@
 		<spectraltype>sdB</spectraltype>
 		<planet>
 			<name>KOI-55 b</name>
+			<name>Kepler-70 b</name>
+			<name>KOI-55.01</name>
+			<name>KIC 5807616 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.0014</mass>
 			<radius>0.068</radius>
@@ -29,6 +32,9 @@
 		</planet>
 		<planet>
 			<name>KOI-55 c</name>
+			<name>Kepler-70 c</name>
+			<name>KOI-55.02</name>
+			<name>KIC 5807616 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.0021</mass>
 			<radius>0.078</radius>
@@ -41,6 +47,8 @@
 			<temperature>6319.1</temperature>
 		</planet>
 		<name>KOI-55</name>
+		<name>Kepler-70</name>
+		<name>KIC 5807616</name>
 		<temperature>27730.0</temperature>
 	</star>
 	<videolink>http://youtu.be/R4wK-nt4Elk</videolink>

--- a/systems/Kepler-10.xml
+++ b/systems/Kepler-10.xml
@@ -5,6 +5,8 @@
 	<distance errorminus="27" errorplus="27">173</distance>
 	<star>
 		<name>Kepler-10</name>
+		<name>KOI-72</name>
+		<name>KIC 11904151</name>
 		<temperature errorminus="75" errorplus="75">5643</temperature>
 		<mass errorminus="0.021" errorplus="0.021">0.91</mass>
 		<radius errorminus="0.009" errorplus="0.009">1.065</radius>
@@ -18,6 +20,8 @@
 		<age errorminus="1.3" errorplus="1.5">10.6</age>
 		<planet>
 			<name>Kepler-10 b</name>
+			<name>KOI-72.01</name>
+			<name>KOI-72 b</name>
 			<name>KIC 11904151 b</name>
 			<name>2MASS J19024305+5014286 b</name>
 			<list>Confirmed planets</list>
@@ -36,6 +40,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-10 c</name>
+			<name>KOI-72.02</name>
+			<name>KOI-72 c</name>
 			<name>KIC 11904151 c</name>
 			<name>2MASS J19024305+5014286 c</name>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-100.xml
+++ b/systems/Kepler-100.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-100 c</name>
 			<name>KOI-41.01</name>
+			<name>KOI-41 c</name>
 			<name>KIC 6521045 c</name>
 			<period>12.8159</period>
 			<radius errorminus="0.004557" errorplus="0.004557">0.200487</radius>
@@ -36,6 +37,7 @@
 		<planet>
 			<name>Kepler-100 b</name>
 			<name>KOI-41.02</name>
+			<name>KOI-41 b</name>
 			<name>KIC 6521045 b</name>
 			<period>6.88705</period>
 			<radius errorminus="0.003645" errorplus="0.003645">0.120292</radius>
@@ -50,6 +52,7 @@
 		<planet>
 			<name>Kepler-100 d</name>
 			<name>KOI-41.03</name>
+			<name>KOI-41 d</name>
 			<name>KIC 6521045 d</name>
 			<period>35.3331</period>
 			<radius errorminus="0.004557" errorplus="0.004557">0.146720</radius>

--- a/systems/Kepler-102.xml
+++ b/systems/Kepler-102.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-102 e</name>
 			<name>KOI-82.01</name>
+			<name>KOI-82 e</name>
 			<name>KIC 10187017 e</name>
 			<period>16.1457</period>
 			<radius errorminus="0.006379" errorplus="0.006379">0.202309</radius>
@@ -36,6 +37,7 @@
 		<planet>
 			<name>Kepler-102 d</name>
 			<name>KOI-82.02</name>
+			<name>KOI-82 d</name>
 			<name>KIC 10187017 d</name>
 			<period>10.3117</period>
 			<radius errorminus="0.003645" errorplus="0.003645">0.107534</radius>
@@ -50,6 +52,7 @@
 		<planet>
 			<name>Kepler-102 f</name>
 			<name>KOI-82.03</name>
+			<name>KOI-82 f</name>
 			<name>KIC 10187017 f</name>
 			<period>27.4536</period>
 			<radius errorminus="0.002734" errorplus="0.002734">0.080195</radius>
@@ -64,6 +67,7 @@
 		<planet>
 			<name>Kepler-102 c</name>
 			<name>KOI-82.04</name>
+			<name>KOI-82 c</name>
 			<name>KIC 10187017 c</name>
 			<period>7.07142</period>
 			<radius errorminus="0.001823" errorplus="0.001823">0.052856</radius>
@@ -78,6 +82,7 @@
 		<planet>
 			<name>Kepler-102 b</name>
 			<name>KOI-82.05</name>
+			<name>KOI-82 b</name>
 			<name>KIC 10187017 b</name>
 			<period>5.28696</period>
 			<radius errorminus="0.001823" errorplus="0.001823">0.042831</radius>

--- a/systems/Kepler-103.xml
+++ b/systems/Kepler-103.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-103 b</name>
 			<name>KOI-108.01</name>
+			<name>KOI-108 b</name>
 			<name>KIC 4914423 b</name>
 			<period>15.9654</period>
 			<radius errorminus="0.008202" errorplus="0.008202">0.307109</radius>
@@ -36,6 +37,7 @@
 		<planet>
 			<name>Kepler-103 c</name>
 			<name>KOI-108.02</name>
+			<name>KOI-108 c</name>
 			<name>KIC 4914423 c</name>
 			<period>179.612</period>
 			<radius errorminus="0.012758" errorplus="0.012758">0.468410</radius>

--- a/systems/Kepler-106.xml
+++ b/systems/Kepler-106.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-106 c</name>
 			<name>KOI-116.01</name>
+			<name>KOI-116 c</name>
 			<name>KIC 8395660 c</name>
 			<period>13.5708</period>
 			<radius errorminus="0.029162" errorplus="0.029162">0.227826</radius>
@@ -36,6 +37,7 @@
 		<planet>
 			<name>Kepler-106 e</name>
 			<name>KOI-116.02</name>
+			<name>KOI-116 e</name>
 			<name>KIC 8395660 e</name>
 			<period>43.8445</period>
 			<radius errorminus="0.030073" errorplus="0.030073">0.233294</radius>
@@ -50,6 +52,7 @@
 		<planet>
 			<name>Kepler-106 b</name>
 			<name>KOI-116.03</name>
+			<name>KOI-116 b</name>
 			<name>KIC 8395660 b</name>
 			<period>6.16486</period>
 			<radius errorminus="0.010024" errorplus="0.010024">0.074727</radius>
@@ -64,6 +67,7 @@
 		<planet>
 			<name>Kepler-106 d</name>
 			<name>KOI-116.04</name>
+			<name>KOI-116 d</name>
 			<name>KIC 8395660 d</name>
 			<period>23.9802</period>
 			<radius errorminus="0.011847" errorplus="0.011847">0.086574</radius>

--- a/systems/Kepler-109.xml
+++ b/systems/Kepler-109.xml
@@ -24,6 +24,7 @@
 		<planet>
 			<name>Kepler-109 b</name>
 			<name>KOI-123.01</name>
+			<name>KOI-123 b</name>
 			<name>KIC 5094751 b</name>
 			<name>TYC 3138-1820-1 b</name>
 			<name>2MASS J19213425+4017055 b</name>
@@ -40,6 +41,7 @@
 		<planet>
 			<name>Kepler-109 c</name>
 			<name>KOI-123.02</name>
+			<name>KOI-123 c</name>
 			<name>KIC 5094751 c</name>
 			<name>TYC 3138-1820-1 c</name>
 			<name>2MASS J19213425+4017055 c</name>

--- a/systems/Kepler-11.xml
+++ b/systems/Kepler-11.xml
@@ -5,6 +5,8 @@
 	<distance>613.20279</distance>
 	<star>
 		<name>Kepler-11</name>
+		<name>KOI-157</name>
+		<name>KIC 6541920</name>
 		<mass errorminus="0.024" errorplus="0.027">0.961</mass>
 		<radius errorminus="0.015" errorplus="0.013">1.053</radius>
 		<temperature errorminus="67" errorplus="55">5663</temperature>
@@ -17,6 +19,9 @@
 		<age errorminus="1.3" errorplus="1.2">8.1</age>
 		<planet>
 			<name>Kepler-11 b</name>
+			<name>KOI-157.06</name>
+			<name>KOI-157 b</name>
+			<name>KIC 6541920 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.003146" errorplus="0.004404">0.005977</mass>
 			<radius errorminus="0.001823" errorplus="0.001823">0.164035</radius>
@@ -38,6 +43,9 @@ Image credit: NASA/Tim Pyle</imagedescription>
 		</planet>
 		<planet>
 			<name>Kepler-11 c</name>
+			<name>KOI-157.01</name>
+			<name>KOI-157 c</name>
+			<name>KIC 6541920 c</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.000063" errorplus="0.000031">0.009028</mass>
 			<radius errorminus="0.001823" errorplus="0.000911">0.261544</radius>
@@ -59,6 +67,9 @@ Image credit: NASA/Tim Pyle</imagedescription>
 		</planet>
 		<planet>
 			<name>Kepler-11 d</name>
+			<name>KOI-157.02</name>
+			<name>KOI-157 d</name>
+			<name>KIC 6541920 d</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.004719" errorplus="0.002517">0.022964</mass>
 			<radius errorminus="0.001823" errorplus="0.001823">0.283415</radius>
@@ -80,6 +91,9 @@ Image credit: NASA/Tim Pyle</imagedescription>
 		</planet>
 		<planet>
 			<name>Kepler-11 e</name>
+			<name>KOI-157.03</name>
+			<name>KOI-157 e</name>
+			<name>KIC 6541920 e</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.006606" errorplus="0.004719">0.025166</mass>
 			<radius errorminus="0.001823" errorplus="0.001823">0.380925</radius>
@@ -101,6 +115,9 @@ Image credit: NASA/Tim Pyle</imagedescription>
 		</planet>
 		<planet>
 			<name>Kepler-11 f</name>
+			<name>KOI-157.04</name>
+			<name>KOI-157 f</name>
+			<name>KIC 6541920 f</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.002831" errorplus="0.002517">0.006291</mass>
 			<radius errorminus="0.002734" errorplus="0.001823">0.226003</radius>
@@ -122,6 +139,9 @@ Image credit: NASA/Tim Pyle</imagedescription>
 		</planet>
 		<planet>
 			<name>Kepler-11 g</name>
+			<name>KOI-157.05</name>
+			<name>KOI-157 g</name>
+			<name>KIC 6541920 g</name>
 			<list>Confirmed planets</list>
 			<mass upperlimit="0.078643" />
 			<radius errorminus="0.001823" errorplus="0.001823">0.303464</radius>

--- a/systems/Kepler-113.xml
+++ b/systems/Kepler-113.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-113 c</name>
 			<name>KOI-153.01</name>
+			<name>KOI-153 c</name>
 			<name>KIC 12252424 c</name>
 			<period>8.92507</period>
 			<radius errorminus="0.005468" errorplus="0.005468">0.198664</radius>
@@ -34,6 +35,7 @@
 		<planet>
 			<name>Kepler-113 b</name>
 			<name>KOI-153.02</name>
+			<name>KOI-153 b</name>
 			<name>KIC 12252424 b</name>
 			<period>4.75400</period>
 			<radius errorminus="0.004557" errorplus="0.004557">0.165857</radius>

--- a/systems/Kepler-12.xml
+++ b/systems/Kepler-12.xml
@@ -17,6 +17,7 @@
 		<planet>
 			<name>Kepler-12 b</name>
 			<name>GSC 03549-00844 b</name>
+			<name>KOI-20.01</name>
 			<name>KOI-20 b</name>
 			<name>2MASS J19045842+5002253 b</name>
 			<name>KIC 11804465 b</name>
@@ -35,6 +36,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-12</name>
+		<name>KOI-20</name>
+		<name>KIC 11804465</name>
 		<temperature>5947.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-128.xml
+++ b/systems/Kepler-128.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>Kepler-128</name>
 		<name>KOI-274</name>
+		<name>KIC 8077137</name>
 		<name>TYC 3130-1733-1</name>
 		<magB errorminus="0.12" errorplus="0.12">12.06</magB>
 		<magV errorminus="0.13" errorplus="0.13">11.69</magV>

--- a/systems/Kepler-13.xml
+++ b/systems/Kepler-13.xml
@@ -6,6 +6,7 @@
 	<binary>
 		<name>Kepler-13</name>
 		<name>KOI-13</name>
+		<name>KIC 9941662</name>
 		<name>BD+46 2629</name>
 		<separation errorminus="0.05" errorplus="0.05" unit="arcsec">1.15</separation>
 		<separation errorminus="120" errorplus="120" unit="AU">610</separation>
@@ -13,6 +14,7 @@
 		<star>
 			<name>Kepler-13 A</name>
 			<name>KOI-13 A</name>
+			<name>KIC 9941662 A</name>
 			<name>BD+46 2629 A</name>
 			<name>PPM 57894</name>
 			<name>TYC 3542-64-1</name>
@@ -32,6 +34,7 @@
 				<name>Kepler-13 b</name>
 				<name>KOI-13 b</name>
 				<name>KOI-13.01</name>
+				<name>KIC 9941662 A b</name>
 				<name>BD+46 2629 A b</name>
 				<name>PPM 57894 b</name>
 				<mass lowerlimit="4.94" upperlimit="8.09" />
@@ -52,6 +55,9 @@
 			</planet>
 		</star>
 		<binary>
+			<name>Kepler-13 BC</name>
+			<name>KOI-13 BC</name>
+			<name>KIC 9941662 BC</name>
 			<period errorminus="0.029" errorplus="0.029">65.831</period>
 			<eccentricity errorminus="0.02" errorplus="0.02">0.52</eccentricity>
 			<periastron errorminus="3" errorplus="3">32</periastron>
@@ -59,6 +65,8 @@
 			<semimajoraxis>0.41</semimajoraxis>
 			<star>
 				<name>Kepler-13 B</name>
+				<name>KOI-13 B</name>
+				<name>KIC 9941662 B</name>
 				<name>BD+46 2629 B</name>
 				<name>TYC 3542-64-2</name>
 				<magV>10.2</magV>
@@ -71,6 +79,8 @@
 			</star>
 			<star>
 				<name>Kepler-13 C</name>
+				<name>KOI-13 C</name>
+				<name>KIC 9941662 C</name>
 				<name>BD+46 2629 C</name>
 				<temperature upperlimit="4700" />
 				<mass errorminus="0.175" errorplus="0.175">0.575</mass>

--- a/systems/Kepler-131.xml
+++ b/systems/Kepler-131.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-131 b</name>
 			<name>KOI-283.01</name>
+			<name>KOI-283 b</name>
 			<name>KIC 5695396 b</name>
 			<period>16.0920</period>
 			<radius errorminus="0.018226" errorplus="0.018226">0.219624</radius>
@@ -36,6 +37,7 @@
 		<planet>
 			<name>Kepler-131 c</name>
 			<name>KOI-283.02</name>
+			<name>KOI-283 c</name>
 			<name>KIC 5695396 c</name>
 			<period>25.5169</period>
 			<radius errorminus="0.006379" errorplus="0.006379">0.076549</radius>

--- a/systems/Kepler-14.xml
+++ b/systems/Kepler-14.xml
@@ -20,6 +20,7 @@
 			<name>KIC 10264660 b</name>
 			<name>TYC 3546-00413-1 b</name>
 			<name>2MASS J19105011+4719589 b</name>
+			<name>KOI-98.01</name>
 			<name>KOI-98 b</name>
 			<list>Confirmed planets</list>
 			<mass>8.4</mass>
@@ -35,6 +36,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-14</name>
+		<name>KOI-98</name>
+		<name>KIC 10264660</name>
 		<temperature>6395.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-15.xml
+++ b/systems/Kepler-15.xml
@@ -15,6 +15,7 @@
 		<planet>
 			<name>Kepler-15 b</name>
 			<name>2MASS J19444814+4908244 b</name>
+			<name>KOI-128.01</name>
 			<name>KOI-128 b</name>
 			<name>KIC 11359879 b</name>
 			<list>Confirmed planets</list>
@@ -32,6 +33,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-15</name>
+		<name>KOI-128</name>
+		<name>KIC 11359879</name>
 		<temperature>5595.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-16.xml
+++ b/systems/Kepler-16.xml
@@ -7,6 +7,9 @@
 	<magH errorminus="0.03" errorplus="0.03">9.14</magH>
 	<magK errorminus="0.022" errorplus="0.022">8.996</magK>
 	<binary>
+		<name>Kepler-16</name>
+		<name>KOI-1611</name>
+		<name>KIC 12644769</name>
 		<magB>12.1</magB>
 		<magR errorminus="0.06" errorplus="0.06">11.90</magR>
 		<semimajoraxis>0.22</semimajoraxis>
@@ -18,16 +21,24 @@
 			<metallicity>-0.3</metallicity>
 			<spectraltype>K</spectraltype>
 			<name>Kepler-16 A</name>
+			<name>KOI-1611 A</name>
+			<name>KIC 12644769 A</name>
 		</star>
 		<star>
 			<mass>0.20255</mass>
 			<radius>0.22623</radius>
 			<spectraltype>M</spectraltype>
 			<name>Kepler-16 B</name>
+			<name>KOI-1611 B</name>
+			<name>KOI-1611.01</name>
+			<name>KIC 12644769 B</name>
 		</star>
 		<planet>
 			<name>Kepler-16 (AB) b</name>
 			<name>Kepler-16 b</name>
+			<name>KOI-1611.02</name>
+			<name>KOI-1611 (AB) b</name>
+			<name>KIC 12644769 (AB) b</name>
 			<list>Confirmed planets</list>
 			<mass>0.333</mass>
 			<radius>0.7538</radius>

--- a/systems/Kepler-17.xml
+++ b/systems/Kepler-17.xml
@@ -17,6 +17,7 @@
 		<planet>
 			<name>Kepler-17 b</name>
 			<name>2MASS J19533486+4748540 b</name>
+			<name>KOI-203.01</name>
 			<name>KOI-203 b</name>
 			<name>KIC 10619192 b</name>
 			<list>Confirmed planets</list>
@@ -35,6 +36,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-17</name>
+		<name>KOI-203</name>
+		<name>KIC 10619192</name>
 		<temperature>5781.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-18.xml
+++ b/systems/Kepler-18.xml
@@ -4,6 +4,8 @@
 	<declination>+44 44 47</declination>
 	<star>
 		<name>Kepler-18</name>
+		<name>KOI-137</name>
+		<name>KIC 8644288</name>
 		<temperature>5383.0</temperature>
 		<mass>0.972</mass>
 		<radius>1.108</radius>

--- a/systems/Kepler-21.xml
+++ b/systems/Kepler-21.xml
@@ -23,6 +23,7 @@
 			<name>SAO 67891 b</name>
 			<name>2MASS J19092683+3842505 b</name>
 			<name>KIC 3632418 b</name>
+			<name>KOI-975.01</name>
 			<name>KOI-975 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.033</mass>
@@ -40,6 +41,9 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-21</name>
+		<name>KOI-975</name>
+		<name>KIC 3632418</name>
+		<name>HIP 94112</name>
 		<temperature>6131.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-27.xml
+++ b/systems/Kepler-27.xml
@@ -5,6 +5,8 @@
 	<distance>991.22</distance>
 	<star>
 		<name>Kepler-27</name>
+		<name>KOI-841</name>
+		<name>KIC 5792202</name>
 		<temperature>5400.0</temperature>
 		<mass>0.65</mass>
 		<radius>0.59</radius>
@@ -15,6 +17,7 @@
 		<planet>
 			<name>Kepler-27 b</name>
 			<name>KOI-841.01</name>
+			<name>KOI-841 b</name>
 			<name>KIC 5792202 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.364521</radius>
@@ -31,6 +34,7 @@
 		<planet>
 			<name>Kepler-27 c</name>
 			<name>KOI-841.02</name>
+			<name>KOI-841 c</name>
 			<name>KIC 5792202 c</name>
 			<list>Confirmed planets</list>
 			<radius>0.44653</radius>

--- a/systems/Kepler-277.xml
+++ b/systems/Kepler-277.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>Kepler-277</name>
 		<name>KOI-1215</name>
+		<name>KIC 3939150</name>
 		<magJ errorminus="0.021" errorplus="0.021">12.288</magJ>
 		<magH errorminus="0.022" errorplus="0.022">12.003</magH>
 		<magK errorminus="0.023" errorplus="0.023">11.966</magK>

--- a/systems/Kepler-28.xml
+++ b/systems/Kepler-28.xml
@@ -5,6 +5,8 @@
 	<distance>772.8</distance>
 	<star>
 		<name>Kepler-28</name>
+		<name>KOI-870</name>
+		<name>KIC 6949607</name>
 		<temperature>4590.0</temperature>
 		<mass>0.75</mass>
 		<radius>0.70</radius>
@@ -16,6 +18,7 @@
 		<planet>
 			<name>Kepler-28 b</name>
 			<name>KOI-870.01</name>
+			<name>KOI-870 b</name>
 			<name>KIC 6949607 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.32806906</radius>
@@ -32,6 +35,7 @@
 		<planet>
 			<name>Kepler-28 c</name>
 			<name>KOI-870.02</name>
+			<name>KOI-870 c</name>
 			<name>KIC 6949607 c</name>
 			<list>Confirmed planets</list>
 			<radius>0.30984</radius>

--- a/systems/Kepler-289.xml
+++ b/systems/Kepler-289.xml
@@ -39,6 +39,9 @@
 		</planet>
 		<planet>
 			<name>PH3 c</name>
+			<name>Kepler-289 d</name>
+			<name>KOI-1353 d</name>
+			<name>KIC 7303287 d</name>
 			<mass errorminus="0.003" errorplus="0.003">0.013</mass>
 			<radius errorminus="0.015" errorplus="0.015">0.239</radius>
 			<period errorminus="0.0114" errorplus="0.0114">66.0634</period>

--- a/systems/Kepler-29.xml
+++ b/systems/Kepler-29.xml
@@ -5,6 +5,8 @@
 	<distance>1246</distance>
 	<star>
 		<name>Kepler-29</name>
+		<name>KOI-738</name>
+		<name>KIC 10358759</name>
 		<temperature>5750.0</temperature>
 		<mass>1.0</mass>
 		<radius>0.96</radius>
@@ -15,6 +17,7 @@
 		<planet>
 			<name>Kepler-29 b</name>
 			<name>KOI-738.01</name>
+			<name>KOI-738 b</name>
 			<name>KIC 10358759 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.328069</radius>
@@ -31,6 +34,7 @@
 		<planet>
 			<name>Kepler-29 c</name>
 			<name>KOI-738.02</name>
+			<name>KOI-738 c</name>
 			<name>KIC 10358759 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.3</mass>

--- a/systems/Kepler-32.xml
+++ b/systems/Kepler-32.xml
@@ -5,6 +5,8 @@
 	<distance>399</distance>
 	<star>
 		<name>Kepler-32</name>
+		<name>KOI-952</name>
+		<name>KIC 9787239</name>
 		<temperature>3900.0</temperature>
 		<magJ errorminus="0.023" errorplus="0.023">13.616</magJ>
 		<magH errorminus="0.024" errorplus="0.024">12.901</magH>

--- a/systems/Kepler-4.xml
+++ b/systems/Kepler-4.xml
@@ -18,6 +18,7 @@
 			<name>Kepler-4 b</name>
 			<name>2MASS J19022767+5008087 b</name>
 			<name>KIC 11853905 b</name>
+			<name>KOI-7.01</name>
 			<name>KOI-7 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.077</mass>
@@ -34,6 +35,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-4</name>
+		<name>KOI-7</name>
+		<name>KIC 11853905</name>
 		<temperature>5857.0</temperature>
 	</star>
 	<videolink>http://youtu.be/qJl9BeAPfhI</videolink>

--- a/systems/Kepler-406.xml
+++ b/systems/Kepler-406.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-406 b</name>
 			<name>KOI-321.01</name>
+			<name>KOI-321 b</name>
 			<name>KIC 8753657 b</name>
 			<period>2.42629</period>
 			<radius errorminus="0.002734" errorplus="0.002734">0.130316</radius>
@@ -34,6 +35,7 @@
 		<planet>
 			<name>Kepler-406 c</name>
 			<name>KOI-321.02</name>
+			<name>KOI-321 c</name>
 			<name>KIC 8753657 c</name>
 			<period>4.62332</period>
 			<radius errorminus="0.002734" errorplus="0.002734">0.077461</radius>

--- a/systems/Kepler-407.xml
+++ b/systems/Kepler-407.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-407 b</name>
 			<name>KOI-1442.01</name>
+			<name>KOI-1442 b</name>
 			<name>KIC 11600889 b</name>
 			<period>0.669310</period>
 			<radius errorminus="0.001823" errorplus="0.001823">0.097509</radius>
@@ -34,6 +35,7 @@
 		<planet>
 			<name>Kepler-407 c</name>
 			<name>KOI-1442.10</name>
+			<name>KOI-1442 c</name>
 			<name>KIC 11600889 c</name>
 			<period errorminus="500" errorplus="500">3000</period>
 			<mass errorminus="6.291401" errorplus="6.291401">12.582803</mass>

--- a/systems/Kepler-409.xml
+++ b/systems/Kepler-409.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-409 b</name>
 			<name>KOI-1925.01</name>
+			<name>KOI-1925 b</name>
 			<name>KIC 9955598 b</name>
 			<period>68.9584</period>
 			<radius errorminus="0.002734" errorplus="0.002734">0.108445</radius>

--- a/systems/Kepler-41.xml
+++ b/systems/Kepler-41.xml
@@ -9,6 +9,7 @@
 		<magK errorminus="0.028" errorplus="0.028">12.892</magK>
 		<name>Kepler-41</name>
 		<name>KOI-196</name>
+		<name>KIC 9410930</name>
 		<name>2MASS J19380317+4558539</name>
 		<mass errorminus="0.07" errorplus="0.07">1.15</mass>
 		<radius errorminus="0.02" errorplus="0.02">1.29</radius>
@@ -20,6 +21,7 @@
 			<name>Kepler-41 b</name>
 			<name>KOI-196 b</name>
 			<name>KOI-196.01</name>
+			<name>KIC 9410930 b</name>
 			<name>2MASS J19380317+4558539 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.08" errorplus="0.08">0.56</mass>

--- a/systems/Kepler-42.xml
+++ b/systems/Kepler-42.xml
@@ -7,6 +7,7 @@
 	<star>
 		<name>Kepler-42</name>
 		<name>KOI-961</name>
+		<name>KIC 8561063</name>
 		<magB errorminus="0.14" errorplus="0.14">17.96</magB>
 		<magV errorminus="0.055" errorplus="0.055">16.124</magV>
 		<magR>16.06</magR>

--- a/systems/Kepler-434.xml
+++ b/systems/Kepler-434.xml
@@ -18,6 +18,7 @@
 		<planet>
 			<name>Kepler-434 b</name>
 			<name>KOI-614.01</name>
+			<name>KOI-614 b</name>
 			<name>KIC 7368664 b</name>
 			<name>2MASS J19342073+4255440 b</name>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-436.xml
+++ b/systems/Kepler-436.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-436 b</name>
 			<name>KOI-2529.02</name>
 			<name>KOI-2529 b</name>
+			<name>KIC 8463346 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.021" errorplus="0.021">0.244</radius>
 			<period errorminus="0.00053" errorplus="0.00072">64.00205</period>

--- a/systems/Kepler-437.xml
+++ b/systems/Kepler-437.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-437 b</name>
 			<name>KOI-3255.01</name>
 			<name>KOI-3255 b</name>
+			<name>KIC 8183288 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.015" errorplus="0.020">0.191</radius>
 			<period errorminus="0.00032" errorplus="0.00033">66.65062</period>

--- a/systems/Kepler-438.xml
+++ b/systems/Kepler-438.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-438 b</name>
 			<name>KOI-3284.01</name>
 			<name>KOI-3284 b</name>
+			<name>KIC 6497146 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.015" errorplus="0.014">0.100</radius>
 			<period errorminus="0.00029" errorplus="0.00025">35.23319</period>

--- a/systems/Kepler-439.xml
+++ b/systems/Kepler-439.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-439 b</name>
 			<name>KOI-4005.01</name>
 			<name>KOI-4005 b</name>
+			<name>KIC 8142787 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.040" errorplus="0.014">0.200</radius>
 			<period errorminus="0.0018" errorplus="0.0016">178.1396</period>

--- a/systems/Kepler-440.xml
+++ b/systems/Kepler-440.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-440 b</name>
 			<name>KOI-4087.01</name>
 			<name>KOI-4087 b</name>
+			<name>KIC 6106282 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.017" errorplus="0.021">0.166</radius>
 			<period errorminus="0.00068" errorplus="0.00087">101.11141</period>

--- a/systems/Kepler-441.xml
+++ b/systems/Kepler-441.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-441 b</name>
 			<name>KOI-4622.01</name>
 			<name>KOI-4622 b</name>
+			<name>KIC 11284772 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.021" errorplus="0.020">0.146</radius>
 			<period errorminus="0.0020" errorplus="0.0022">207.2482</period>

--- a/systems/Kepler-442.xml
+++ b/systems/Kepler-442.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-442 b</name>
 			<name>KOI-4742.01</name>
 			<name>KOI-4742 b</name>
+			<name>KIC 4138008 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.016" errorplus="0.010">0.120</radius>
 			<period errorminus="0.0028" errorplus="0.0024">112.3053</period>

--- a/systems/Kepler-443.xml
+++ b/systems/Kepler-443.xml
@@ -20,6 +20,7 @@
 			<name>Kepler-443 b</name>
 			<name>KOI-4745.01</name>
 			<name>KOI-4745 b</name>
+			<name>KIC 11757451 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.020" errorplus="0.017">0.208</radius>
 			<period errorminus="0.0030" errorplus="0.0031">177.6693</period>

--- a/systems/Kepler-444.xml
+++ b/systems/Kepler-444.xml
@@ -7,6 +7,7 @@
 		<name>Kepler-444</name>
 		<name>HIP 94931</name>
 		<name>KOI-3158</name>
+		<name>KIC 6278762</name>
 		<name>LHS 3450</name>
 		<name>PPM 58152</name>
 		<name>TYC 3129-329-1</name>
@@ -27,7 +28,9 @@
 		<planet>
 			<name>Kepler-444 b</name>
 			<name>HIP 94931 b</name>
+			<name>KOI-3158.01</name>
 			<name>KOI-3158 b</name>
+			<name>KIC 6278762 b</name>
 			<name>LHS 3450 b</name>
 			<name>PPM 58152 b</name>
 			<name>TYC 3129-329-1 b</name>
@@ -47,7 +50,9 @@
 		<planet>
 			<name>Kepler-444 c</name>
 			<name>HIP 94931 c</name>
+			<name>KOI-3158.02</name>
 			<name>KOI-3158 c</name>
+			<name>KIC 6278762 c</name>
 			<name>LHS 3450 c</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.001549" errorplus="0.001914">0.045292</radius>
@@ -64,7 +69,9 @@
 		<planet>
 			<name>Kepler-444 d</name>
 			<name>HIP 94931 d</name>
+			<name>KOI-3158.03</name>
 			<name>KOI-3158 d</name>
+			<name>KIC 6278762 d</name>
 			<name>LHS 3450 d</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.001731" errorplus="0.002005">0.048299</radius>
@@ -81,7 +88,9 @@
 		<planet>
 			<name>Kepler-444 e</name>
 			<name>HIP 94931 e</name>
+			<name>KOI-3158.04</name>
 			<name>KOI-3158 e</name>
+			<name>KIC 6278762 e</name>
 			<name>LHS 3450 e</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.001367" errorplus="0.001549">0.049757</radius>
@@ -98,7 +107,9 @@
 		<planet>
 			<name>Kepler-444 f</name>
 			<name>HIP 94931 f</name>
+			<name>KOI-3158.05</name>
 			<name>KOI-3158 f</name>
+			<name>KIC 6278762 f</name>
 			<name>LHS 3450 f</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.003645" errorplus="0.003736">0.067528</radius>

--- a/systems/Kepler-46.xml
+++ b/systems/Kepler-46.xml
@@ -38,6 +38,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-46 c</name>
+			<name>KIC 7109675 c</name>
+			<name>KOI-872 c</name>
 			<mass errorminus="0.019" errorplus="0.021">0.376</mass>
 			<period errorminus="0.000030" errorplus="0.000030">57.011</period>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-5.xml
+++ b/systems/Kepler-5.xml
@@ -15,6 +15,7 @@
 			<name>Kepler-5 b</name>
 			<name>2MASS J19573768+4402061 b</name>
 			<name>KIC 8191672 b</name>
+			<name>KOI-18.01</name>
 			<name>KOI-18 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.059" errorplus="0.056">2.114</mass>
@@ -31,6 +32,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-5</name>
+		<name>KOI-18</name>
+		<name>KIC 8191672</name>
 		<temperature errorminus="60" errorplus="60">6297.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-6.xml
+++ b/systems/Kepler-6.xml
@@ -15,6 +15,7 @@
 			<name>Kepler-6 b</name>
 			<name>2MASS J19472094+4814238 b</name>
 			<name>KIC 10874614 b</name>
+			<name>KOI-17.01</name>
 			<name>KOI-17 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.669</mass>
@@ -31,6 +32,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-6</name>
+		<name>KOI-17</name>
+		<name>KIC 10874614</name>
 		<temperature>5647.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-61.xml
+++ b/systems/Kepler-61.xml
@@ -22,6 +22,7 @@
 		<spectraltype>K7V</spectraltype>
 		<planet>
 			<name>Kepler-61 b</name>
+			<name>KOI-1361.01</name>
 			<name>KOI-1361 b</name>
 			<name>KIC 6960913 b</name>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-65.xml
+++ b/systems/Kepler-65.xml
@@ -20,6 +20,7 @@
 		<spectraltype>F</spectraltype>
 		<planet>
 			<name>Kepler-65 b</name>
+			<name>KOI-85.02</name>
 			<name>KOI-85 b</name>
 			<name>KIC 5866724 b</name>
 			<list>Confirmed planets</list>
@@ -36,6 +37,7 @@
 		</planet>
 		<planet>
 			<name>Kepler-65 c</name>
+			<name>KOI-85.01</name>
 			<name>KOI-85 c</name>
 			<name>KIC 5866724 c</name>
 			<list>Confirmed planets</list>
@@ -52,6 +54,7 @@
 		</planet>
 		<planet>
 			<name>Kepler-65 d</name>
+			<name>KOI-85.03</name>
 			<name>KOI-85 d</name>
 			<name>KIC 5866724 d</name>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-66.xml
+++ b/systems/Kepler-66.xml
@@ -5,6 +5,8 @@
 	<distance errorminus="90" errorplus="90">1107</distance>
 	<star>
 		<name>Kepler-66</name>
+		<name>KOI-1958</name>
+		<name>KIC 9836149</name>
 		<mass errorminus="0.044" errorplus="0.044">1.038</mass>
 		<radius errorminus="0.042" errorplus="0.042">0.966</radius>
 		<temperature errorminus="79" errorplus="79">5962</temperature>
@@ -18,6 +20,9 @@
 		<age errorminus="0.17" errorplus="0.17">1</age>
 		<planet>
 			<name>Kepler-66 b</name>
+			<name>KOI-1958.01</name>
+			<name>KOI-1958 b</name>
+			<name>KIC 9836149 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.014581" errorplus="0.014581">0.255165</radius>
 			<period errorminus="0.000075" errorplus="0.000075">17.815815</period>

--- a/systems/Kepler-67.xml
+++ b/systems/Kepler-67.xml
@@ -5,6 +5,8 @@
 	<distance errorminus="90" errorplus="90">1107</distance>
 	<star>
 		<name>Kepler-67</name>
+		<name>KOI-2115</name>
+		<name>KIC 9532052</name>
 		<mass errorminus="0.034" errorplus="0.034">0.865</mass>
 		<radius errorminus="0.031" errorplus="0.031">0.778</radius>
 		<temperature errorminus="63" errorplus="63">5331</temperature>
@@ -17,6 +19,9 @@
 		<age errorminus="0.17" errorplus="0.17">1</age>
 		<planet>
 			<name>Kepler-67 b</name>
+			<name>KOI-2115.01</name>
+			<name>KOI-2115 b</name>
+			<name>KIC 9532052 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.014581" errorplus="0.014581">0.267923</radius>
 			<period errorminus="0.00011" errorplus="0.00011">15.72590</period>

--- a/systems/Kepler-68.xml
+++ b/systems/Kepler-68.xml
@@ -5,6 +5,7 @@
 	<distance>135</distance>
 	<star>
 		<name>Kepler-68</name>
+		<name>KOI-246</name>
 		<name>KIC 11295426</name>
 		<name>2MASS J19240775+4902249</name>
 		<mass>1.079</mass>
@@ -23,6 +24,7 @@
 			<name>KIC 11295426 b</name>
 			<name>2MASS J19240775+4902249 b</name>
 			<name>KOI-246.01</name>
+			<name>KOI-246 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.02610931</mass>
 			<radius>0.2105109</radius>
@@ -43,6 +45,7 @@
 			<name>KIC 11295426 c</name>
 			<name>2MASS J19240775+4902249 c</name>
 			<name>KOI-246.02</name>
+			<name>KOI-246 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.01509936</mass>
 			<radius>0.0868471</radius>
@@ -61,6 +64,7 @@
 			<name>KIC 11295426 d</name>
 			<name>2MASS J19240775+4902249 d</name>
 			<name>KOI-246.20</name>
+			<name>KOI-246 d</name>
 			<list>Confirmed planets</list>
 			<mass>0.947</mass>
 			<period>580</period>

--- a/systems/Kepler-69.xml
+++ b/systems/Kepler-69.xml
@@ -10,6 +10,7 @@
 		<magK errorminus="0.026" errorplus="0.026">12.234</magK>
 		<name>Kepler-69</name>
 		<name>KOI-172</name>
+		<name>KIC 8692861</name>
 		<mass>0.81</mass>
 		<radius>0.93</radius>
 		<temperature>5638</temperature>
@@ -17,7 +18,9 @@
 		<spectraltype>G4V</spectraltype>
 		<planet>
 			<name>Kepler-69 b</name>
+			<name>KOI-172.01</name>
 			<name>KOI-172 b</name>
+			<name>KIC 8692861 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.2041318</radius>
 			<temperature>779</temperature>
@@ -34,7 +37,9 @@
 		</planet>
 		<planet>
 			<name>Kepler-69 c</name>
+			<name>KOI-172.02</name>
 			<name>KOI-172 c</name>
+			<name>KIC 8692861 c</name>
 			<list>Confirmed planets</list>
 			<radius>0.1558328</radius>
 			<temperature>299</temperature>

--- a/systems/Kepler-7.xml
+++ b/systems/Kepler-7.xml
@@ -16,6 +16,7 @@
 			<name>Kepler-7 b</name>
 			<name>2MASS J19141956+4105233 b</name>
 			<name>KIC 5780885 b</name>
+			<name>KOI-97.01</name>
 			<name>KOI-97 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.433</mass>
@@ -32,6 +33,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-7</name>
+		<name>KOI-97</name>
+		<name>KIC 5780885</name>
 		<temperature>5933.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-71.xml
+++ b/systems/Kepler-71.xml
@@ -10,6 +10,8 @@
 		<magH errorminus="0.023" errorplus="0.023">13.550</magH>
 		<magK errorminus="0.04" errorplus="0.04">13.47</magK>
 		<name>Kepler-71</name>
+		<name>KOI-217</name>
+		<name>KIC 9595827</name>
 		<temperature errorminus="138.00" errorplus="138.00">5543.00</temperature>
 		<radius errorminus="0.0680" errorplus="0.0680">0.8870</radius>
 		<mass errorminus="0.0790" errorplus="0.0790">0.9230</mass>
@@ -18,6 +20,7 @@
 			<name>Kepler-71 b</name>
 			<name>KOI-217 b</name>
 			<name>KOI-217.01</name>
+			<name>KIC 9595827 b</name>
 			<radius errorminus="0.51033" errorplus="0.51033">1.06622</radius>
 			<period errorminus="1.785e-07" errorplus="1.785e-07">3.9050814125</period>
 			<transittime errorminus="0.0000006" errorplus="0.0000006">2454966.4143153</transittime>

--- a/systems/Kepler-75.xml
+++ b/systems/Kepler-75.xml
@@ -7,6 +7,7 @@
 	<distance errorminus="250" errorplus="160">1140</distance>
 	<star>
 		<name>Kepler-75</name>
+		<name>KOI-889</name>
 		<name>KIC 757450</name>
 		<name>2MASS 19243302+3634385</name>
 		<magB>16.2</magB>

--- a/systems/Kepler-76.xml
+++ b/systems/Kepler-76.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>Kepler-76</name>
 		<name>KIC 4570949</name>
+		<name>KOI-1658</name>
 		<mass errorminus="0.2" errorplus="0.2">1.2</mass>
 		<radius errorminus="0.08" errorplus="0.08">1.32</radius>
 		<temperature errorminus="95" errorplus="95">6409</temperature>
@@ -16,6 +17,8 @@
 		<spectraltype>G2V</spectraltype>
 		<planet>
 			<name>Kepler-76 b</name>
+			<name>KOI-1658.01</name>
+			<name>KOI-1658 b</name>
 			<name>KIC 4570949 b</name>
 			<name>Einstein's Planet</name>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-77.xml
+++ b/systems/Kepler-77.xml
@@ -15,6 +15,7 @@
 		<magH errorminus="0.019" errorplus="0.019">12.444</magH>
 		<magK errorminus="0.018" errorplus="0.018">12.361</magK>
 		<name>Kepler-77</name>
+		<name>KOI-127</name>
 		<name>KIC 8359498</name>
 		<name>GSC2.3 N2K0000444</name>
 		<name>USNO-A2 1275-11111739</name>

--- a/systems/Kepler-8.xml
+++ b/systems/Kepler-8.xml
@@ -18,6 +18,7 @@
 			<name>Kepler-8 b</name>
 			<name>2MASS J18450914+4227038 b</name>
 			<name>KIC 6922244 b</name>
+			<name>KOI-10.01</name>
 			<name>KOI-10 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.19" errorplus="0.13">0.603</mass>
@@ -34,6 +35,8 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<name>Kepler-8</name>
+		<name>KOI-10</name>
+		<name>KIC 6922244</name>
 		<temperature errorminus="150" errorplus="150">6213.0</temperature>
 	</star>
 </system>

--- a/systems/Kepler-89.xml
+++ b/systems/Kepler-89.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>Kepler-89</name>
 		<name>KOI-94</name>
+		<name>KIC 6462863</name>
 		<mass>1.277</mass>
 		<radius>1.52</radius>
 		<magJ errorminus="0.022" errorplus="0.022">11.218</magJ>

--- a/systems/Kepler-9.xml
+++ b/systems/Kepler-9.xml
@@ -5,6 +5,8 @@
 	<distance>650</distance>
 	<star>
 		<name>Kepler-9</name>
+		<name>KOI-377</name>
+		<name>KIC 3323887</name>
 		<temperature>5722.0</temperature>
 		<spectraltype>G2</spectraltype>
 		<mass errorminus="0.03" errorplus="0.03">1.05</mass>
@@ -19,6 +21,7 @@
 			<name>Kepler-9 b</name>
 			<name>2MASS J19021775+3824032 b</name>
 			<name>KIC 3323887 b</name>
+			<name>KOI-377.01</name>
 			<name>KOI-377 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.00471953186" errorplus="0.00471953186">0.141900591</mass>
@@ -38,6 +41,7 @@
 			<name>Kepler-9 c</name>
 			<name>2MASS J19021775+3824032 c</name>
 			<name>KIC 3323887 c</name>
+			<name>KOI-377.02</name>
 			<name>KOI-377 c</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.00314635457" errorplus="0.00314635457">0.0975369917</mass>
@@ -57,6 +61,7 @@
 			<name>Kepler-9 d</name>
 			<name>2MASS J19021775+3824032 d</name>
 			<name>KIC 3323887 d</name>
+			<name>KOI-377.03</name>
 			<name>KOI-377 d</name>
 			<list>Confirmed planets</list>
 			<mass>0.022</mass>

--- a/systems/Kepler-91.xml
+++ b/systems/Kepler-91.xml
@@ -10,6 +10,7 @@
 		<magK errorminus="0.021" errorplus="0.021">10.136</magK>
 		<name>Kepler-91</name>
 		<name>KIC 8219268</name>
+		<name>KOI-2133</name>
 		<mass errorminus="0.10" errorplus="0.10">1.31</mass>
 		<radius errorminus="0.16" errorplus="0.16">6.30</radius>
 		<metallicity errorminus="0.07" errorplus="0.07">0.11</metallicity>
@@ -18,6 +19,7 @@
 			<name>Kepler-91 b</name>
 			<name>KIC 8219268 b</name>
 			<name>KOI-2133.01</name>
+			<name>KOI-2133 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.06" errorplus="0.06">0.66</mass>
 			<radius errorminus="0.04" errorplus="0.04">1.40</radius>

--- a/systems/Kepler-93.xml
+++ b/systems/Kepler-93.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-93 b</name>
 			<name>KOI-69.01</name>
+			<name>KOI-69 b</name>
 			<name>KIC 3544595 b</name>
 			<period errorminus="0.00000097" errorplus="0.00000097">4.72673978</period>
 			<radius errorminus="0.0017" errorplus="0.0017">0.1319</radius>
@@ -39,6 +40,7 @@
 		<planet>
 			<name>Kepler-93 c</name>
 			<name>KOI-69.10</name>
+			<name>KOI-69 c</name>
 			<name>KIC 3544595 c</name>
 			<period lowerlimit="3700" />
 			<mass lowerlimit="8.5" upperlimit="670" />

--- a/systems/Kepler-94.xml
+++ b/systems/Kepler-94.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-94 b</name>
 			<name>KOI-104.01</name>
+			<name>KOI-104 b</name>
 			<name>KIC 10318874 b</name>
 			<period>2.50806</period>
 			<radius errorminus="0.013670" errorplus="0.013670">0.319867</radius>
@@ -34,6 +35,7 @@
 		<planet>
 			<name>Kepler-94 c</name>
 			<name>KOI-104.10</name>
+			<name>KOI-104 c</name>
 			<name>KIC 10318874 c</name>
 			<period errorminus="3" errorplus="3">820.3</period>
 			<mass errorminus="0.629140" errorplus="0.629140">9.833460</mass>

--- a/systems/Kepler-95.xml
+++ b/systems/Kepler-95.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-95 b</name>
 			<name>KOI-122.01</name>
+			<name>KOI-122 b</name>
 			<name>KIC 8349582 b</name>
 			<period>11.5231</period>
 			<radius errorminus="0.008202" errorplus="0.008202">0.311666</radius>

--- a/systems/Kepler-96.xml
+++ b/systems/Kepler-96.xml
@@ -22,6 +22,7 @@
 		<planet>
 			<name>Kepler-96 b</name>
 			<name>KOI-261.01</name>
+			<name>KOI-261 b</name>
 			<name>KIC 5383248 b</name>
 			<period>16.2385</period>
 			<radius errorminus="0.020049" errorplus="0.020049">0.243318</radius>

--- a/systems/Kepler-97.xml
+++ b/systems/Kepler-97.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-97 b</name>
 			<name>KOI-292.01</name>
+			<name>KOI-292 b</name>
 			<name>KIC 11075737 b</name>
 			<period>2.58664</period>
 			<radius errorminus="0.011847" errorplus="0.011847">0.134873</radius>
@@ -34,6 +35,7 @@
 		<planet>
 			<name>Kepler-97 c</name>
 			<name>KOI-292.10</name>
+			<name>KOI-292 c</name>
 			<name>KIC 11075737 c</name>
 			<period lowerlimit="789" />
 			<list>Confirmed planets</list>

--- a/systems/Kepler-98.xml
+++ b/systems/Kepler-98.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-98 b</name>
 			<name>KOI-299.01</name>
+			<name>KOI-299 b</name>
 			<name>KIC 2692377 b</name>
 			<period>1.54168</period>
 			<radius errorminus="0.020049" errorplus="0.020049">0.181349</radius>

--- a/systems/Kepler-99.xml
+++ b/systems/Kepler-99.xml
@@ -20,6 +20,7 @@
 		<planet>
 			<name>Kepler-99 b</name>
 			<name>KOI-305.01</name>
+			<name>KOI-305 b</name>
 			<name>KIC 6063220 b</name>
 			<period>4.60358</period>
 			<radius errorminus="0.007290" errorplus="0.007290">0.134873</radius>

--- a/systems/PH-1.xml
+++ b/systems/PH-1.xml
@@ -7,22 +7,32 @@
 	<magH errorminus="0.022" errorplus="0.022">12.461</magH>
 	<magK errorminus="0.021" errorplus="0.021">12.395</magK>
 	<binary>
+		<name>PH-1</name>
+		<name>Kepler-64</name>
+		<name>KIC 4862625</name>
 		<separation unit="arcsec">0.7</separation>
 		<separation unit="AU">1000</separation>
 		<positionangle>123</positionangle>
 		<binary>
+			<name>PH-1 A</name>
+			<name>Kepler-64 A</name>
+			<name>KIC 4862625 A</name>
 			<period>20.000214</period>
 			<semimajoraxis>0.1744</semimajoraxis>
 			<eccentricity>0.21166048</eccentricity>
 			<periastron>348</periastron>
 			<star>
 				<name>PH-1 Aa</name>
+				<name>Kepler-64 Aa</name>
+				<name>KIC 4862625 Aa</name>
 				<mass>1.384</mass>
 				<radius>1.759</radius>
 				<spectraltype>F</spectraltype>
 			</star>
 			<star>
 				<name>PH-1 Ab</name>
+				<name>Kepler-64 Ab</name>
+				<name>KIC 4862625 Ab</name>
 				<mass>0.386</mass>
 				<radius>0.422</radius>
 				<spectraltype>M</spectraltype>
@@ -54,15 +64,22 @@
 			</planet>
 		</binary>
 		<binary>
+			<name>PH-1 B</name>
+			<name>Kepler-64 B</name>
+			<name>KIC 4862625 B</name>
 			<separation unit="arcsec" upperlimit="0.4" />
 			<separation unit="AU" upperlimit="60" />
 			<star>
 				<name>PH-1 Ba</name>
+				<name>Kepler-64 Ba</name>
+				<name>KIC 4862625 Ba</name>
 				<mass>0.99</mass>
 				<spectraltype>G2</spectraltype>
 			</star>
 			<star>
 				<name>PH-1 Bb</name>
+				<name>Kepler-64 Bb</name>
+				<name>KIC 4862625 Bb</name>
 				<mass>0.51</mass>
 				<spectraltype>M2</spectraltype>
 			</star>

--- a/systems/PH-2.xml
+++ b/systems/PH-2.xml
@@ -6,6 +6,8 @@
 	<distance>369.8</distance>
 	<star>
 		<name>PH-2</name>
+		<name>Kepler-86</name>
+		<name>KOI-3663</name>
 		<name>KIC 12735740</name>
 		<name>2MASS 19190326+5157453</name>
 		<metallicity>-0.07</metallicity>
@@ -14,6 +16,8 @@
 		<radius>1.0</radius>
 		<planet>
 			<name>PH-2 b</name>
+			<name>KOI-3663.01</name>
+			<name>KOI-3663 b</name>
 			<name>KIC 12735740 b</name>
 			<name>2MASS 19190326+5157453 b</name>
 			<name>Planet Hunters 2 b</name>

--- a/systems/TrES-2.xml
+++ b/systems/TrES-2.xml
@@ -30,6 +30,9 @@
 				<name>TrES-2 A b</name>
 				<name>TrES-2 b</name>
 				<name>Kepler-1 b</name>
+				<name>KOI-1.01</name>
+				<name>KOI-1 b</name>
+				<name>KIC 11446443 b</name>
 				<list>Confirmed planets</list>
 				<list>Planets in binary systems, S-type</list>
 				<mass>1.253</mass>


### PR DESCRIPTION
Reference: NASA Exoplanet Archive / Kepler names table

Culled from the bulk Kepler update. This consists of systems where the only change was to add new designations.