### PR TITLE
Fix mismatched KOI/KIC designations

### DIFF
--- a/systems/KOI-680.xml
+++ b/systems/KOI-680.xml
@@ -6,7 +6,7 @@
 	<star>
 		<name>KOI-680</name>
 		<name>Kepler-435</name>
-		<name>KIC 75292669</name>
+		<name>KIC 7529266</name>
 		<name>2MASS J19290895+4311502</name>
 		<mass errorminus="0.088" errorplus="0.088">1.538</mass>
 		<radius errorminus="0.30" errorplus="0.30">3.21</radius>
@@ -21,8 +21,9 @@
 		<temperature errorminus="110" errorplus="110">6090</temperature>
 		<planet>
 			<name>KOI-680 b</name>
+			<name>KOI-680.01</name>
 			<name>Kepler-435 b</name>
-			<name>KIC 75292669 b</name>
+			<name>KIC 7529266 b</name>
 			<name>2MASS J19290895+4311502 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.18" errorplus="0.18">1.99</radius>

--- a/systems/KOI-806.xml
+++ b/systems/KOI-806.xml
@@ -4,8 +4,9 @@
 	<declination>+38 56 50</declination>
 	<distance>924.9</distance>
 	<star>
-		<name>KOI-0806</name>
+		<name>KOI-806</name>
 		<name>Kepler-30</name>
+		<name>KIC 3832474</name>
 		<magB errorminus="0.42" errorplus="0.42">16.50</magB>
 		<magR errorminus="0.25" errorplus="0.25">15.95</magR>
 		<magI errorminus="0.44" errorplus="0.44">14.55</magI>
@@ -18,8 +19,9 @@
 		<magK errorminus="0.05" errorplus="0.05">13.58</magK>
 		<spectraltype>G</spectraltype>
 		<planet>
-			<name>KOI-806.01</name>
+			<name>KOI-806.03</name>
 			<name>Kepler-30 b</name>
+			<name>KOI-806 b</name>
 			<name>KIC 3832474 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.004404" errorplus="0.004404">0.035546</mass>
@@ -41,6 +43,7 @@
 		<planet>
 			<name>KOI-806.02</name>
 			<name>Kepler-30 c</name>
+			<name>KOI-806 c</name>
 			<name>KIC 3832474 c</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.157285" errorplus="0.157285">2.013248</mass>
@@ -60,8 +63,9 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<planet>
-			<name>KOI-806.03</name>
+			<name>KOI-806.01</name>
 			<name>Kepler-30 d</name>
+			<name>KOI-806 d</name>
 			<name>KIC 3832474 d</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.008493" errorplus="0.008493">0.072666</mass>

--- a/systems/Kepler-25.xml
+++ b/systems/Kepler-25.xml
@@ -5,6 +5,8 @@
 	<distance>191</distance>
 	<star>
 		<name>Kepler-25</name>
+		<name>KOI-244</name>
+		<name>KIC 4349452</name>
 		<mass>1.22</mass>
 		<radius>1.36</radius>
 		<magB errorminus="0.07" errorplus="0.07">11.32</magB>
@@ -17,8 +19,9 @@
 		<temperature>6190.0</temperature>
 		<planet>
 			<name>Kepler-25 b</name>
-			<name>KIC 3231341 b</name>
-			<name>KOI-244.01</name>
+			<name>KIC 4349452 b</name>
+			<name>KOI-244.02</name>
+			<name>KOI-244 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.2369387</radius>
 			<period>6.238</period>
@@ -33,8 +36,9 @@
 		</planet>
 		<planet>
 			<name>Kepler-25 c</name>
-			<name>KIC 3231341 c</name>
-			<name>KOI-244.02</name>
+			<name>KIC 4349452 c</name>
+			<name>KOI-244.01</name>
+			<name>KOI-244 c</name>
 			<list>Confirmed planets</list>
 			<radius>0.410086</radius>
 			<period>12.72</period>
@@ -51,6 +55,7 @@
 			<name>Kepler-25 d</name>
 			<name>KOI-244.10</name>
 			<name>KIC 4349452 d</name>
+			<name>KOI-244 d</name>
 			<period errorminus="2" errorplus="2">123</period>
 			<mass errorminus="0.043096" errorplus="0.043096">0.282798</mass>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-33.xml
+++ b/systems/Kepler-33.xml
@@ -5,6 +5,8 @@
 	<distance>917.8</distance>
 	<star>
 		<name>Kepler-33</name>
+		<name>KOI-707</name>
+		<name>KIC 9458613</name>
 		<temperature errorminus="47" errorplus="47">5904.0</temperature>
 		<magB errorminus="0.42" errorplus="0.42">14.39</magB>
 		<magV errorminus="0.28" errorplus="0.28">13.74</magV>
@@ -19,7 +21,8 @@
 		<age errorminus="1.03" errorplus="0.74">4.27</age>
 		<planet>
 			<name>Kepler-33 b</name>
-			<name>KOI-707.01</name>
+			<name>KOI-707.05</name>
+			<name>KOI-707 b</name>
 			<name>KIC 9458613 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.158566</radius>
@@ -36,7 +39,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-33 c</name>
-			<name>KOI-707.02</name>
+			<name>KOI-707.04</name>
+			<name>KOI-707 c</name>
 			<name>KIC 9458613 c</name>
 			<list>Confirmed planets</list>
 			<radius>0.2916</radius>
@@ -53,7 +57,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-33 d</name>
-			<name>KOI-707.03</name>
+			<name>KOI-707.01</name>
+			<name>KOI-707 d</name>
 			<name>KIC 9458613 d</name>
 			<list>Confirmed planets</list>
 			<radius>0.487547</radius>
@@ -70,7 +75,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-33 e</name>
-			<name>KOI-707.04</name>
+			<name>KOI-707.03</name>
+			<name>KOI-707 e</name>
 			<name>KIC 9458613 e</name>
 			<list>Confirmed planets</list>
 			<radius>0.366343</radius>
@@ -86,7 +92,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-33 f</name>
-			<name>KOI-707.05</name>
+			<name>KOI-707.02</name>
+			<name>KOI-707 f</name>
 			<name>KIC 9458613 f</name>
 			<list>Confirmed planets</list>
 			<radius>0.406441</radius>

--- a/systems/Kepler-36.xml
+++ b/systems/Kepler-36.xml
@@ -5,6 +5,8 @@
 	<distance>436.937</distance>
 	<star>
 		<name>Kepler-36</name>
+		<name>KIC 11401755</name>
+		<name>KOI-277</name>
 		<temperature>5911.0</temperature>
 		<magB errorminus="0.24" errorplus="0.24">12.66</magB>
 		<magV errorminus="0.17" errorplus="0.17">11.94</magV>
@@ -15,7 +17,8 @@
 		<radius>1.619</radius>
 		<planet>
 			<name>Kepler-36 b</name>
-			<name>KOI-277.01</name>
+			<name>KOI-277.02</name>
+			<name>KOI-277 b</name>
 			<name>KIC 11401755 b</name>
 			<name>2MASS 19250004+4913545 b</name>
 			<list>Confirmed planets</list>
@@ -37,7 +40,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-36 c</name>
-			<name>KOI-277.02</name>
+			<name>KOI-277.01</name>
+			<name>KOI-277 c</name>
 			<name>KIC 11401755 c</name>
 			<name>2MASS 19250004+4913545 c</name>
 			<list>Confirmed planets</list>


### PR DESCRIPTION
Culled from the Kepler bulk update.

Cases where KIC numbers were incorrect or KOI nnn.nn designations were assigned to incorrect planets.