### PR TITLE
Update KOI-285

### DIFF
--- a/systems/KOI-285.xml
+++ b/systems/KOI-285.xml
@@ -7,6 +7,7 @@
 	<star>
 		<name>KOI-285</name>
 		<name>Kepler-92</name>
+		<name>KIC 6196457</name>
 		<mass errorminus="0.46" errorplus="0.34">1.17</mass>
 		<radius errorminus="0.19" errorplus="0.19">1.53</radius>
 		<magB errorminus="0.23" errorplus="0.23">12.50</magB>
@@ -20,6 +21,7 @@
 			<name>KOI-285 b</name>
 			<name>KOI-285.01</name>
 			<name>Kepler-92 b</name>
+			<name>KIC 6196457 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.0437343285" errorplus="0.0437343285">0.202310599</mass>
 			<radius errorminus="0.039" errorplus="0.039">0.314</radius>
@@ -36,6 +38,7 @@
 			<name>KOI-285 c</name>
 			<name>KOI-285.02</name>
 			<name>Kepler-92 c</name>
+			<name>KIC 6196457 c</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.00566343823" errorplus="0.00566343823">0.0191927629</mass>
 			<radius errorminus="0.029" errorplus="0.029">0.233</radius>
@@ -49,7 +52,6 @@
 			<discoveryyear>2013</discoveryyear>
 		</planet>
 		<planet>
-			<name>KOI-285 d</name>
 			<name>KOI-285.03</name>
 			<radius errorminus="0.02187" errorplus="0.02187">0.16768</radius>
 			<period errorminus="7.40000e-04" errorplus="7.40000e-04">49.358990000000</period>


### PR DESCRIPTION
Added the KIC identifiers to this system.

As far as I can tell, KOI-285.03 has not yet been confirmed and has not yet been assigned a letter designation. In case someone discovers a different planet in the system before this one is confirmed, it is probably better to hold off on assigning the letter "d" in order to respect the designation assignments of future researchers.