### PR TITLE
Kepler-445 d has no corresponding KOI identifer.

### DIFF
--- a/systems/Kepler-445.xml
+++ b/systems/Kepler-445.xml
@@ -56,9 +56,7 @@
 		<planet>
 			<name>Kepler-445 d</name>
 			<name>KOI-2704 d</name>
-			<name>KOI-2704.03</name>
 			<name>KIC 9730163 d</name>
-			<name>KIC 9730163.03</name>
 			<list>Confirmed planets</list>
 			<mass lowerlimit="3" upperlimit="4" />
 			<radius errorminus="0.19" errorplus="0.19">1.25</radius>


### PR DESCRIPTION
NASA KOI Catalog lists only two KOIs for this system, corresponding to planets b and c. There is no KOI-2704.03, and the Kepler names table lists Kepler-445 d as not being in the KOI list. The discovery paper [Muirhead et al. (2013)](http://adsabs.harvard.edu/abs/2015ApJ...801...18M) also notes that the third object in this system was missed by the Kepler pipeline.