### PR TITLE
KOI and KIC identifiers

### DIFF
--- a/systems/Kepler-20.xml
+++ b/systems/Kepler-20.xml
@@ -5,6 +5,8 @@
 	<distance>290</distance>
 	<star>
 		<name>Kepler-20</name>
+		<name>KOI-70</name>
+		<name>KIC 6850504</name>
 		<temperature>5466.0</temperature>
 		<mass>0.912</mass>
 		<radius>0.944</radius>
@@ -20,7 +22,9 @@
 		<planet>
 			<name>Kepler-20 b</name>
 			<name>2MASS J19104752+4220194 b</name>
-			<name>KOI-70</name>
+			<name>KOI-70.02</name>
+			<name>KOI-70 b</name>
+			<name>KIC 6850504 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.027</mass>
 			<radius>0.17</radius>
@@ -38,7 +42,9 @@
 		<planet>
 			<name>Kepler-20 c</name>
 			<name>2MASS J19104752+4220194 c</name>
-			<name>KOI-070</name>
+			<name>KOI-70.01</name>
+			<name>KOI-70 c</name>
+			<name>KIC 6850504 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.051</mass>
 			<radius>0.27</radius>
@@ -56,7 +62,9 @@
 		<planet>
 			<name>Kepler-20 d</name>
 			<name>2MASS J19104752+4220194 d</name>
-			<name>KOI-070</name>
+			<name>KOI-70.03</name>
+			<name>KOI-70 d</name>
+			<name>KIC 6850504 d</name>
 			<list>Confirmed planets</list>
 			<mass>0.06</mass>
 			<radius>0.25</radius>
@@ -74,7 +82,9 @@
 		<planet>
 			<name>Kepler-20 e</name>
 			<name>2MASS J19104752+4220194 e</name>
-			<name>KOI-070.04</name>
+			<name>KOI-70.04</name>
+			<name>KOI-70 e</name>
+			<name>KIC 6850504 e</name>
 			<list>Confirmed planets</list>
 			<radius>0.0791</radius>
 			<period>6.098493</period>
@@ -91,7 +101,9 @@
 		<planet>
 			<name>Kepler-20 f</name>
 			<name>2MASS J19104752+4220194 f</name>
-			<name>KOI-070.05</name>
+			<name>KOI-70.05</name>
+			<name>KOI-70 f</name>
+			<name>KIC 6850504 f</name>
 			<list>Confirmed planets</list>
 			<radius>0.093</radius>
 			<period>19.57706</period>

--- a/systems/Kepler-22.xml
+++ b/systems/Kepler-22.xml
@@ -20,7 +20,9 @@
 		<magK errorminus="0.014" errorplus="0.014">10.152</magK>
 		<planet>
 			<name>Kepler-22 b</name>
-			<name>KIC10593626 b</name>
+			<name>KOI-87.01</name>
+			<name>KOI-87 b</name>
+			<name>KIC 10593626 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.21689</radius>
 			<period>290</period>

--- a/systems/Kepler-410.xml
+++ b/systems/Kepler-410.xml
@@ -27,7 +27,7 @@
 				<name>HD 175289 b</name>
 				<name>KIC 8866102 b</name>
 				<name>KOI-42 b</name>
-				<name>KOI-42 01</name>
+				<name>KOI-42.01</name>
 				<list>Confirmed planets</list>
 				<period errorminus="0.000054" errorplus="0.000054">17.833648</period>
 				<radius errorminus="0.004921" errorplus="0.004921">0.258628</radius>
@@ -44,6 +44,8 @@
 		</star>
 		<star>
 			<name>Kepler-410 B</name>
+			<name>KIC 8866102 B</name>
+			<name>KOI-42 B</name>
 			<temperature>4850</temperature>
 		</star>
 	</binary>

--- a/systems/Kepler-412.xml
+++ b/systems/Kepler-412.xml
@@ -6,7 +6,8 @@
 	<star>
 		<name>Kepler-412</name>
 		<name>KOI-202</name>
-		<name>2MASS 19042647+4340514 b</name>
+		<name>2MASS 19042647+4340514</name>
+		<name>KIC 7877496</name>
 		<magB errorminus="0.33" errorplus="0.33">14.41</magB>
 		<magV errorminus="0.24" errorplus="0.24">13.73</magV>
 		<magR errorminus="0.11" errorplus="0.11">14.67</magR>
@@ -22,7 +23,9 @@
 		<age errorminus="1.7" errorplus="1.7">5.1</age>
 		<planet>
 			<name>Kepler-412 b</name>
+			<name>KOI-202.01</name>
 			<name>KOI-202 b</name>
+			<name>KIC 7877496 b</name>
 			<name>2MASS 19042647+4340514 b</name>
 			<mass errorminus="0.085" errorplus="0.085">0.939</mass>
 			<radius errorminus="0.043" errorplus="0.043">1.325</radius>

--- a/systems/Kepler-418.xml
+++ b/systems/Kepler-418.xml
@@ -7,15 +7,17 @@
 		<magH errorminus="0.03" errorplus="0.03">13.24</magH>
 		<magK errorminus="0.03" errorplus="0.03">13.10</magK>
 		<name>Kepler-418</name>
-		<name>KOI 1089</name>
+		<name>KOI-1089</name>
 		<name>KIC 3247268</name>
 		<mass errorminus="0.08" errorplus="0.08">0.98</mass>
 		<radius errorminus="0.14" errorplus="0.14">1.09</radius>
 		<temperature errorminus="100" errorplus="100">5820</temperature>
 		<metallicity errorminus="0.10" errorplus="0.10">-0.05</metallicity>
 		<planet>
-			<name>Kepler-418b</name>
 			<name>Kepler-418 b</name>
+			<name>KOI-1089.01</name>
+			<name>KOI-1089 b</name>
+			<name>KIC 3247268 b</name>
 			<list>Confirmed planets</list>
 			<mass>1.1</mass>
 			<radius errorminus="5.2" errorplus="5.2" unit="Re">9.7</radius>

--- a/systems/Kepler-421.xml
+++ b/systems/Kepler-421.xml
@@ -5,7 +5,7 @@
 	<distance errorminus="20" errorplus="20">320</distance>
 	<star>
 		<name>Kepler-421</name>
-		<name>KIC-8800954</name>
+		<name>KIC 8800954</name>
 		<name>KOI-1274</name>
 		<mass errorminus="0.03" errorplus="0.03">0.794</mass>
 		<radius errorminus="0.029" errorplus="0.029">0.757</radius>
@@ -18,7 +18,8 @@
 		<age errorminus="0.8" errorplus="0.8">4</age>
 		<planet>
 			<name>Kepler-421 b</name>
-			<name>KIC-8800954 b</name>
+			<name>KIC 8800954 b</name>
+			<name>KOI-1274.01</name>
 			<name>KOI-1274 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.014581" errorplus="0.017315">0.379102</radius>

--- a/systems/Kepler-447.xml
+++ b/systems/Kepler-447.xml
@@ -4,7 +4,7 @@
 	<declination>+48 33 36.05</declination>
 	<star>
 		<name>Kepler-447</name>
-		<name>KIC-11017901</name>
+		<name>KIC 11017901</name>
 		<name>KOI-1800</name>
 		<name>2MASS J19010446+4833360</name>
 		<mass errorminus="0.49" errorplus="0.145">0.764</mass>
@@ -17,7 +17,8 @@
 		<metallicity errorminus="0.05" errorplus="0.05">0.07</metallicity>
 		<planet>
 			<name>Kepler-447 b</name>
-			<name>KIC-11017901 b</name>
+			<name>KIC 11017901 b</name>
+			<name>KOI-1800.01</name>
 			<name>KOI-1800 b</name>
 			<name>2MASS J19010446+4833360 b</name>
 			<list>Confirmed planets</list>

--- a/systems/Kepler-45.xml
+++ b/systems/Kepler-45.xml
@@ -5,6 +5,8 @@
 	<distance errorminus="33" errorplus="33">333</distance>
 	<star>
 		<name>Kepler-45</name>
+		<name>KOI-254</name>
+		<name>KIC 5794240</name>
 		<magV errorminus="0.05" errorplus="0.05">16.88</magV>
 		<magR>16.63</magR>
 		<magJ errorminus="0.024" errorplus="0.024">13.749</magJ>
@@ -19,7 +21,8 @@
 		<planet>
 			<name>Kepler-45 b</name>
 			<name>KOI-254 b</name>
-			<name>KOI-254 01</name>
+			<name>KOI-254.01</name>
+			<name>KIC 5794240 b</name>
 			<radius errorminus="0.11" errorplus="0.11">0.96</radius>
 			<mass errorminus="0.09" errorplus="0.09">0.505</mass>
 			<period errorminus="5e-06" errorplus="5e-06">2.455239</period>

--- a/systems/Kepler-48.xml
+++ b/systems/Kepler-48.xml
@@ -5,6 +5,8 @@
 	<distance>313.14</distance>
 	<star>
 		<name>Kepler-48</name>
+		<name>KOI-148</name>
+		<name>KIC 5735762</name>
 		<temperature>5190.0</temperature>
 		<magJ errorminus="0.024" errorplus="0.024">11.702</magJ>
 		<magH errorminus="0.026" errorplus="0.026">11.292</magH>
@@ -14,7 +16,8 @@
 		<planet>
 			<name>Kepler-48 b</name>
 			<name>KOI-148.01</name>
-			<name>KID 5735762</name>
+			<name>KOI-148 b</name>
+			<name>KIC 5735762 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.015079</mass>
 			<radius>0.195019</radius>
@@ -29,7 +32,8 @@
 		<planet>
 			<name>Kepler-48 c</name>
 			<name>KOI-148.02</name>
-			<name>KID 5735762</name>
+			<name>KOI-148 c</name>
+			<name>KIC 5735762 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.033219</mass>
 			<radius>0.286149</radius>
@@ -44,6 +48,7 @@
 		<planet>
 			<name>Kepler-48 d</name>
 			<name>KOI-148.03</name>
+			<name>KOI-148 d</name>
 			<name>KIC 5735762 d</name>
 			<period>42.8961</period>
 			<radius errorminus="0.010024" errorplus="0.010024">0.185906</radius>
@@ -58,6 +63,7 @@
 		<planet>
 			<name>Kepler-48 e</name>
 			<name>KOI-148.10</name>
+			<name>KOI-148 e</name>
 			<name>KIC 5735762 e</name>
 			<period errorminus="8" errorplus="8">982</period>
 			<mass errorminus="0.078643" errorplus="0.078643">2.066725</mass>

--- a/systems/Kepler-50.xml
+++ b/systems/Kepler-50.xml
@@ -10,6 +10,8 @@
 		<magH errorminus="0.03" errorplus="0.03">9.25</magH>
 		<magK errorminus="0.019" errorplus="0.019">9.197</magK>
 		<name>Kepler-50</name>
+		<name>KOI-262</name>
+		<name>KIC 11807274</name>
 		<temperature>6225</temperature>
 		<metallicity>0.03</metallicity>
 		<mass>1.24</mass>
@@ -18,7 +20,8 @@
 		<planet>
 			<name>Kepler-50 b</name>
 			<name>KOI-262.01</name>
-			<name>KID 11807274</name>
+			<name>KOI-262 b</name>
+			<name>KIC 11807274 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.015963</mass>
 			<radius>0.155832</radius>
@@ -35,7 +38,8 @@
 		<planet>
 			<name>Kepler-50 c</name>
 			<name>KOI-262.02</name>
-			<name>KID 11807274</name>
+			<name>KOI-262 c</name>
+			<name>KIC 11807274 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.026041</mass>
 			<radius>0.1977527</radius>

--- a/systems/Kepler-51.xml
+++ b/systems/Kepler-51.xml
@@ -7,6 +7,7 @@
 	<star>
 		<name>Kepler-51</name>
 		<name>KOI-620</name>
+		<name>KIC 11773022</name>
 		<magJ errorminus="0.023" errorplus="0.023">13.562</magJ>
 		<magH errorminus="0.023" errorplus="0.023">13.219</magH>
 		<magK errorminus="0.037" errorplus="0.037">13.197</magK>
@@ -17,7 +18,8 @@
 		<planet>
 			<name>Kepler-51 b</name>
 			<name>KOI-620.01</name>
-			<name>KID 11773022</name>
+			<name>KOI-620 b</name>
+			<name>KIC 11773022 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.175787</mass>
 			<radius>0.642469</radius>
@@ -32,7 +34,8 @@
 		<planet>
 			<name>Kepler-51 c</name>
 			<name>KOI-620.03</name>
-			<name>KID 11773022</name>
+			<name>KOI-620 c</name>
+			<name>KIC 11773022 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.113864</mass>
 			<radius>0.520354</radius>

--- a/systems/Kepler-57.xml
+++ b/systems/Kepler-57.xml
@@ -5,6 +5,8 @@
 	<distance>570.05</distance>
 	<star>
 		<name>Kepler-57</name>
+		<name>KOI-1270</name>
+		<name>KIC 8564587</name>
 		<temperature>5145.0</temperature>
 		<magJ errorminus="0.024" errorplus="0.024">13.437</magJ>
 		<magH errorminus="0.022" errorplus="0.022">13.022</magH>
@@ -14,7 +16,8 @@
 		<planet>
 			<name>Kepler-57 b</name>
 			<name>KOI-1270.01</name>
-			<name>KID 8564587</name>
+			<name>KOI-1270 b</name>
+			<name>KIC 8564587 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.015814</mass>
 			<radius>0.199575</radius>
@@ -29,7 +32,8 @@
 		<planet>
 			<name>Kepler-57 c</name>
 			<name>KOI-1270.02</name>
-			<name>KID 8564587</name>
+			<name>KOI-1270 c</name>
+			<name>KIC 8564587 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.007759</mass>
 			<radius>0.141252</radius>

--- a/systems/Kepler-59.xml
+++ b/systems/Kepler-59.xml
@@ -5,6 +5,8 @@
 	<distance>811.89</distance>
 	<star>
 		<name>Kepler-59</name>
+		<name>KOI-1529</name>
+		<name>KIC 9821454</name>
 		<temperature>6074.0</temperature>
 		<magJ errorminus="0.028" errorplus="0.028">13.253</magJ>
 		<magH errorminus="0.027" errorplus="0.027">12.974</magH>
@@ -14,7 +16,8 @@
 		<planet>
 			<name>Kepler-59 b</name>
 			<name>KOI-1529.02</name>
-			<name>KID 9821454</name>
+			<name>KOI-1529 b</name>
+			<name>KIC 9821454 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.003828</mass>
 			<radius>0.100243</radius>
@@ -29,7 +32,8 @@
 		<planet>
 			<name>Kepler-59 c</name>
 			<name>KOI-1529.01</name>
-			<name>KID 9821454</name>
+			<name>KOI-1529 c</name>
+			<name>KIC 9821454 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.012848</mass>
 			<radius>0.180438</radius>

--- a/systems/Kepler-60.xml
+++ b/systems/Kepler-60.xml
@@ -5,6 +5,8 @@
 	<distance>664.24</distance>
 	<star>
 		<name>Kepler-60</name>
+		<name>KOI-2086</name>
+		<name>KIC 6768394</name>
 		<temperature>5915.0</temperature>
 		<magJ errorminus="0.023" errorplus="0.023">12.804</magJ>
 		<magH errorminus="0.018" errorplus="0.018">12.569</magH>
@@ -14,7 +16,8 @@
 		<planet>
 			<name>Kepler-60 b</name>
 			<name>KOI-2086.01</name>
-			<name>KID 6768394</name>
+			<name>KOI-2086 b</name>
+			<name>KIC 6768394 b</name>
 			<list>Confirmed planets</list>
 			<mass>0.017182</mass>
 			<radius>0.207777</radius>
@@ -29,7 +32,8 @@
 		<planet>
 			<name>Kepler-60 c</name>
 			<name>KOI-2086.02</name>
-			<name>KID 6768394</name>
+			<name>KOI-2086 c</name>
+			<name>KIC 6768394 c</name>
 			<list>Confirmed planets</list>
 			<mass>0.020262</mass>
 			<radius>0.225092</radius>
@@ -44,7 +48,8 @@
 		<planet>
 			<name>Kepler-60 d</name>
 			<name>KOI-2086.03</name>
-			<name>KID 6768394</name>
+			<name>KOI-2086 d</name>
+			<name>KIC 6768394 d</name>
 			<list>Confirmed planets</list>
 			<mass>0.021637</mass>
 			<radius>0.232382</radius>

--- a/systems/Kepler-62.xml
+++ b/systems/Kepler-62.xml
@@ -7,7 +7,7 @@
 	<distance>368</distance>
 	<star>
 		<name>Kepler-62</name>
-		<name>KIC-9002278</name>
+		<name>KIC 9002278</name>
 		<name>KOI-701</name>
 		<name>2MASS J18525105+4520595</name>
 		<name>GPM 283.213142+45.350276</name>
@@ -24,7 +24,8 @@
 		<magK errorminus="0.021" errorplus="0.021">11.659</magK>
 		<planet>
 			<name>Kepler-62 b</name>
-			<name>KIC-9002278 b</name>
+			<name>KIC 9002278 b</name>
+			<name>KOI-701.02</name>
 			<name>KOI-701 b</name>
 			<list>Confirmed planets</list>
 			<radius>0.1193806</radius>
@@ -41,7 +42,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-62 c</name>
-			<name>KIC-9002278 c</name>
+			<name>KIC 9002278 c</name>
+			<name>KOI-701.05</name>
 			<name>KOI-701 c</name>
 			<list>Confirmed planets</list>
 			<radius>0.049210359</radius>
@@ -58,7 +60,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-62 d</name>
-			<name>KIC-9002278 d</name>
+			<name>KIC 9002278 d</name>
+			<name>KOI-701.01</name>
 			<name>KOI-701 d</name>
 			<list>Confirmed planets</list>
 			<radius>0.1777040</radius>
@@ -75,7 +78,8 @@
 		</planet>
 		<planet>
 			<name>Kepler-62 e</name>
-			<name>KIC-9002278 e</name>
+			<name>KIC 9002278 e</name>
+			<name>KOI-701.03</name>
 			<name>KOI-701 e</name>
 			<list>Confirmed planets</list>
 			<radius>0.14671977</radius>
@@ -96,7 +100,8 @@ Credit: NASA/JPL-Caltech/T. Pyle</imagedescription>
 		</planet>
 		<planet>
 			<name>Kepler-62 f</name>
-			<name>KIC-9002278 f</name>
+			<name>KIC 9002278 f</name>
+			<name>KOI-701.04</name>
 			<name>KOI-701 f</name>
 			<list>Confirmed planets</list>
 			<radius>0.12849371</radius>

--- a/systems/Kepler-74.xml
+++ b/systems/Kepler-74.xml
@@ -7,7 +7,8 @@
 	<distance errorminus="170" errorplus="170">1330</distance>
 	<star>
 		<name>Kepler-74</name>
-		<name>KIC-6046540</name>
+		<name>KOI-200</name>
+		<name>KIC 6046540</name>
 		<name>2MASS 19322220+4121198</name>
 		<name>KIC 6046540</name>
 		<magB>14.5</magB>

--- a/systems/Kepler-87.xml
+++ b/systems/Kepler-87.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>Kepler-87</name>
 		<name>KOI-1574</name>
+		<name>KIC 10028792</name>
 		<magJ errorminus="0.022" errorplus="0.022">13.389</magJ>
 		<magH errorminus="0.022" errorplus="0.022">13.033</magH>
 		<magK errorminus="0.024" errorplus="0.024">12.981</magK>
@@ -17,7 +18,8 @@
 		<planet>
 			<name>Kepler-87 b</name>
 			<name>KOI-1574 b</name>
-			<name>KOI-1574 01</name>
+			<name>KOI-1574.01</name>
+			<name>KIC 10028792 b</name>
 			<radius errorminus="0.026428" errorplus="0.026428">1.229348</radius>
 			<mass errorminus="0.027682" errorplus="0.027682">1.019836</mass>
 			<period errorminus="0.0005" errorplus="0.0005">114.7309</period>
@@ -35,7 +37,8 @@
 		<planet>
 			<name>Kepler-87 c</name>
 			<name>KOI-1574 c</name>
-			<name>KOI-1574 02</name>
+			<name>KOI-1574.02</name>
+			<name>KIC 10028792 c</name>
 			<radius errorminus="0.026428" errorplus="0.026428">0.559540</radius>
 			<mass errorminus="0.002517" errorplus="0.002517">0.020132</mass>
 			<period errorminus="0.074" errorplus="0.074">192.363</period>


### PR DESCRIPTION
Further updates culled from the bulk Kepler update - mainly addition of missing designation forms and some corrections to forms. See individual commit messages for details