### PR TITLE
Remove incorrect 2MASS identifier from WASP-90

### DIFF
--- a/systems/WASP-90.xml
+++ b/systems/WASP-90.xml
@@ -6,7 +6,6 @@
 	<star>
 		<name>WASP-90</name>
 		<name>1SWASP J210207.70+070323.7</name>
-		<name>2MASS 01463185+0242019</name>
 		<mass errorminus="0.1" errorplus="0.1">1.55</mass>
 		<radius errorminus="0.09" errorplus="0.09">1.98</radius>
 		<temperature errorminus="130" errorplus="130">6430</temperature>
@@ -16,7 +15,6 @@
 		<planet>
 			<name>WASP-90 b</name>
 			<name>1SWASP J210207.70+070323.7 b</name>
-			<name>2MASS 01463185+0242019 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.07" errorplus="0.07">0.63</mass>
 			<radius errorminus="0.09" errorplus="0.09">1.63</radius>


### PR DESCRIPTION
Closest 2MASS source to the coordinates is [2MASS 21020767+0703224](http://vizier.u-strasbg.fr/viz-bin/VizieR-5?-ref=VIZ5525a5cc7e0a&-out.add=.&-source=II/246/out&2MASS===21020767%2b0703224) but I have no way of confirming this is the correct identifier. For now I remove the incorrect 2MASS identifier which belongs to WASP-76.

Closes #529