### PR TITLE
Kepler-296: removed binary star designation from planets

### DIFF
--- a/systems/Kepler-296.xml
+++ b/systems/Kepler-296.xml
@@ -22,12 +22,12 @@
 			<mass errorminus="0.012" errorplus="0.012">0.626</mass>
 			<spectraltype>M2V</spectraltype>
 			<planet>
-				<name>Kepler-296 Ac</name>
-				<name>KOI-1422 Ac</name>
-				<name>KOI-1422.01 Ac</name>
-				<name>KIC 11497958 Ac</name>
-				<name>KIC 11497958.01 Ac</name>
-				<name>2MASS J19060960+4926143 Ac</name>
+				<name>Kepler-296 c</name>
+				<name>KOI-1422 c</name>
+				<name>KOI-1422.01</name>
+				<name>KIC 11497958 c</name>
+				<name>KIC 11497958.01 c</name>
+				<name>2MASS J19060960+4926143 c</name>
 				<radius errorminus="0.00460" errorplus="0.00460">0.2513</radius>
 				<mass>0.0214</mass>
 				<temperature errorminus="6.2" errorplus="6.2">558.6</temperature>
@@ -43,12 +43,12 @@
 				<istransiting>1</istransiting>
 			</planet>
 			<planet>
-				<name>Kepler-296 Ad</name>
-				<name>KOI-1422 Ad</name>
-				<name>KOI-1422.02 Ad</name>
-				<name>KIC 11497958 Ad</name>
-				<name>KIC 11497958.02 Ad</name>
-				<name>2MASS J19060960+4926143 Ad</name>
+				<name>Kepler-296 d</name>
+				<name>KOI-1422 d</name>
+				<name>KOI-1422.02</name>
+				<name>KIC 11497958 d</name>
+				<name>KIC 11497958.02 d</name>
+				<name>2MASS J19060960+4926143 d</name>
 				<radius errorminus="0.00552" errorplus="0.00552">0.2623</radius>
 				<mass>0.0223</mass>
 				<temperature errorminus="4.1" errorplus="4.1">371.5</temperature>
@@ -64,12 +64,12 @@
 				<istransiting>1</istransiting>
 			</planet>
 			<planet>
-				<name>Kepler-296 Ab</name>
-				<name>KOI-1422 Ab</name>
-				<name>KOI-1422.03 Ab</name>
-				<name>KIC 11497958 Ab</name>
-				<name>KIC 11497958.03 Ab</name>
-				<name>2MASS J19060960+4926143 Ab</name>
+				<name>Kepler-296 b</name>
+				<name>KOI-1422 b</name>
+				<name>KOI-1422.03</name>
+				<name>KIC 11497958 b</name>
+				<name>KIC 11497958.03 b</name>
+				<name>2MASS J19060960+4926143 b</name>
 				<radius errorminus="0.00552" errorplus="0.00552">0.1123</radius>
 				<mass>0.00692</mass>
 				<temperature errorminus="5.0" errorplus="5.0">454.2</temperature>
@@ -85,12 +85,12 @@
 				<istransiting>1</istransiting>
 			</planet>
 			<planet>
-				<name>Kepler-296 Af</name>
-				<name>KOI-1422 Af</name>
-				<name>KOI-1422.04 Af</name>
-				<name>KIC 11497958 Af</name>
-				<name>KIC 11497958.04 Af</name>
-				<name>2MASS J19060960+4926143 Af</name>
+				<name>Kepler-296 f</name>
+				<name>KOI-1422 f</name>
+				<name>KOI-1422.04</name>
+				<name>KIC 11497958 f</name>
+				<name>KIC 11497958.04 f</name>
+				<name>2MASS J19060960+4926143 f</name>
 				<radius errorminus="0.00828" errorplus="0.00828">0.2145</radius>
 				<mass>0.0186</mass>
 				<temperature errorminus="2.8" errorplus="2.8">252.4</temperature>
@@ -106,12 +106,12 @@
 				<istransiting>1</istransiting>
 			</planet>
 			<planet>
-				<name>Kepler-296 Ae</name>
-				<name>KOI-1422 Ae</name>
-				<name>KOI-1422.05 Ae</name>
-				<name>KIC 11497958 Ae</name>
-				<name>KIC 11497958.05 Ae</name>
-				<name>2MASS J19060960+4926143 Ae</name>
+				<name>Kepler-296 e</name>
+				<name>KOI-1422 e</name>
+				<name>KOI-1422.05</name>
+				<name>KIC 11497958 e</name>
+				<name>KIC 11497958.05 e</name>
+				<name>2MASS J19060960+4926143 e</name>
 				<radius errorminus="0.0203" errorplus="0.0203">0.2089</radius>
 				<mass>0.00714</mass>
 				<temperature errorminus="3.4" errorplus="3.4">310.1</temperature>


### PR DESCRIPTION
Matches format used in discovery paper (Rowe et al. 2014)
Reflects uncertainty about which star in the binary is the host star (Lissauer et al. 2014)

Rowe et al. (2014) http://cdsads.u-strasbg.fr/abs/2014ApJ...784...45R
Lissauer et al. (2014) http://cdsads.u-strasbg.fr/abs/2014ApJ...784...44L