### PR TITLE
Mismatched letter designations (Xie 2014 planets)

### DIFF
--- a/systems/KOI-1873.xml
+++ b/systems/KOI-1873.xml
@@ -9,13 +9,14 @@
 		<magK errorminus="0.07" errorplus="0.07">14.19</magK>
 		<name>KOI-1873</name>
 		<name>Kepler-328</name>
+		<name>KIC 4939346</name>
 		<temperature errorminus="187.00" errorplus="187.00">6134.00</temperature>
 		<radius errorminus="0.3600" errorplus="0.3600">0.9700</radius>
 		<age errorminus="2.1000" errorplus="2.1000">0.3000</age>
 		<mass errorminus="0.66" errorplus="1.60">0.98</mass>
 		<planet>
 			<name>KOI-1873.02</name>
-			<name>KOI-1873 c</name>
+			<name>KOI-1873 b</name>
 			<name>Kepler-328 b</name>
 			<name>KIC 4939346 b</name>
 			<name>KIC 4939346.02</name>
@@ -32,7 +33,7 @@
 		</planet>
 		<planet>
 			<name>KOI-1873.01</name>
-			<name>KOI-1873 b</name>
+			<name>KOI-1873 c</name>
 			<name>Kepler-328 c</name>
 			<name>KIC 4939346 c</name>
 			<name>KIC 4939346.01</name>

--- a/systems/KOI-2672.xml
+++ b/systems/KOI-2672.xml
@@ -17,7 +17,7 @@
 		<temperature>5565</temperature>
 		<planet>
 			<name>KOI-2672.01</name>
-			<name>KOI-2672 b</name>
+			<name>KOI-2672 c</name>
 			<name>Kepler-396 c</name>
 			<name>KIC 11253827 c</name>
 			<name>KIC 11253827.01</name>
@@ -36,7 +36,7 @@
 		</planet>
 		<planet>
 			<name>KOI-2672.02</name>
-			<name>KOI-2672 c</name>
+			<name>KOI-2672 b</name>
 			<name>Kepler-396 b</name>
 			<name>KIC 11253827 b</name>
 			<name>KIC 11253827.02</name>

--- a/systems/KOI-370.xml
+++ b/systems/KOI-370.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>KOI-370</name>
 		<name>Kepler-145</name>
+		<name>KIC 8494142</name>
 		<magJ errorminus="0.025" errorplus="0.025">10.913</magJ>
 		<magH errorminus="0.019" errorplus="0.019">10.693</magH>
 		<magK errorminus="0.016" errorplus="0.016">10.628</magK>
@@ -15,7 +16,7 @@
 		<mass errorminus="0.39" errorplus="0.52">1.26</mass>
 		<planet>
 			<name>KOI-370.02</name>
-			<name>KOI-370 c</name>
+			<name>KOI-370 b</name>
 			<name>Kepler-145 b</name>
 			<name>KIC 8494142 b</name>
 			<name>KIC 8494142.02</name>
@@ -32,7 +33,7 @@
 		</planet>
 		<planet>
 			<name>KOI-370.01</name>
-			<name>KOI-370 b</name>
+			<name>KOI-370 c</name>
 			<name>Kepler-145 c</name>
 			<name>KIC 8494142 c</name>
 			<name>KIC 8494142.01</name>

--- a/systems/KOI-523.xml
+++ b/systems/KOI-523.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>KOI-523</name>
 		<name>Kepler-177</name>
+		<name>KIC 8806123</name>
 		<magJ errorminus="0.025" errorplus="0.025">13.858</magJ>
 		<magH errorminus="0.03" errorplus="0.03">13.57</magH>
 		<magK errorminus="0.04" errorplus="0.04">13.42</magK>
@@ -15,7 +16,7 @@
 		<mass errorminus="0.28" errorplus="0.40">0.93</mass>
 		<planet>
 			<name>KOI-523.02</name>
-			<name>KOI-523 c</name>
+			<name>KOI-523 b</name>
 			<name>Kepler-177 b</name>
 			<name>KIC 8806123 b</name>
 			<name>KIC 8806123.02</name>
@@ -32,7 +33,7 @@
 		</planet>
 		<planet>
 			<name>KOI-523.01</name>
-			<name>KOI-523 b</name>
+			<name>KOI-523 c</name>
 			<name>Kepler-177 c</name>
 			<name>KIC 8806123 c</name>
 			<name>KIC 8806123.01</name>


### PR DESCRIPTION
The 4 systems below appear to have their KOI letter designations set based on the KOI numbering, with .01=b, .02=c, despite the Kepler designations being reversed with respect to this. As far as I can tell, the reversed letters from the "KOI convention" have not actually been used, so there is no reason to preserve this inverted convention.

Discovery paper for all systems is [Xie (2014)](http://adsabs.harvard.edu/abs/2014ApJS..210...25X)