### PR TITLE
Update KOI-1781

### DIFF
--- a/systems/KOI-1781.xml
+++ b/systems/KOI-1781.xml
@@ -17,6 +17,7 @@
 			<name>KOI-1781 b</name>
 			<name>KOI-1781.02</name>
 			<name>Kepler-411 b</name>
+			<name>KIC 11551692 b</name>
 			<list>Confirmed planets</list>
 			<radius errorminus="0.018" errorplus="0.018">0.168</radius>
 			<period errorminus="0.00001" errorplus="0.0001">3.00516</period>
@@ -31,23 +32,21 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<planet>
-			<name>KOI-1781 c</name>
 			<name>KOI-1781.01</name>
-			<list>Confirmed planets</list>
+			<list>Controversial</list>
 			<radius errorminus="0.050" errorplus="0.050">0.289</radius>
 			<period errorminus="0.00001" errorplus="0.00001">7.83445</period>
 			<semimajoraxis errorminus="0.002" errorplus="0.002">0.073</semimajoraxis>
 			<inclination errorminus="1.08" errorplus="0.49">89.03</inclination>
 			<transittime unit="BJD">2454968.2206</transittime>
 			<eccentricity upperlimit="0.66">0.00</eccentricity>
-			<description>The KOI-1781 system was discovered by the Kepler spacecraft. A subsequent analysis has confirmed the planetary nature of this planet.</description>
+			<description>The KOI-1781 system was discovered by the Kepler spacecraft. The second and third planets in this system have not been confirmed.</description>
 			<lastupdate>14/01/06</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<discoveryyear>2013</discoveryyear>
 			<istransiting>1</istransiting>
 		</planet>
 		<planet>
-			<name>KOI-1781 d</name>
 			<name>KOI-1781.03</name>
 			<list>Controversial</list>
 			<radius errorminus="0.028" errorplus="0.028">0.233</radius>
@@ -56,7 +55,7 @@
 			<inclination errorminus="0.16" errorplus="0.35">89.63</inclination>
 			<transittime unit="BJD">2454984.8476</transittime>
 			<eccentricity upperlimit="0.38">0.00</eccentricity>
-			<description>The KOI-1781 system was discovered by the Kepler spacecraft. This third planet candidate in the system has not been confirmed yet.</description>
+			<description>The KOI-1781 system was discovered by the Kepler spacecraft. The second and third planets in this system have not been confirmed.</description>
 			<lastupdate>14/01/06</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<discoveryyear>2013</discoveryyear>


### PR DESCRIPTION
Neither candidate KOI-1781.01 nor KOI-1781.03 are confirmed, nor have they received letter designations. The Wang et al. (2014) paper only gives information for the candidate KOI-1781.02.

Added KIC designation to KOI-1781 b.

Wang et al. (2014) http://adsabs.harvard.edu/abs/2014ApJ...783....4W