### PR TITLE
Update Kepler-307

### DIFF
--- a/systems/Kepler-307.xml
+++ b/systems/Kepler-307.xml
@@ -6,6 +6,7 @@
 	<star>
 		<name>Kepler-307</name>
 		<name>KOI-1576</name>
+		<name>KIC 5299459</name>
 		<magJ errorminus="0.027" errorplus="0.027">12.833</magJ>
 		<magH errorminus="0.028" errorplus="0.028">12.452</magH>
 		<magK errorminus="0.020" errorplus="0.020">12.321</magK>
@@ -48,8 +49,7 @@
 			<istransiting>1</istransiting>
 		</planet>
 		<planet>
-			<name>KOI-1576 d</name>
-			<name>KOI-1576 03</name>
+			<name>KOI-1576.03</name>
 			<radius errorminus="0.06197" errorplus="0.06197">0.14854</radius>
 			<period errorminus="5.20000e-04" errorplus="5.20000e-04">23.340320000000</period>
 			<transittime errorminus="0.0083000" errorplus="0.0083000">2454979.3439000</transittime>


### PR DESCRIPTION
Add KIC designation to star
Use "." as KOI separator
KOI-1576.03 has not been assigned a letter designation.