### PR TITLE
Updated Kepler-25 and HAT-P-7

### DIFF
--- a/systems/HAT-P-7.xml
+++ b/systems/HAT-P-7.xml
@@ -11,16 +11,16 @@
 		<star>
 			<name>HAT-P-7 A</name>
 			<spectraltype>F6</spectraltype>
-			<mass>1.4150</mass>
-			<radius>1.9276</radius>
+			<mass errorminus="0.03" errorplus="0.03">1.59</mass>
+			<radius errorminus="0.01" errorplus="0.01">2.02</radius>
 			<magV errorminus="0.05" errorplus="0.05">10.48</magV>
 			<magB errorminus="0.06" errorplus="0.06">10.97</magB>
 			<magJ errorminus="0.030" errorplus="0.030">9.555</magJ>
 			<magH errorminus="0.029" errorplus="0.029">9.344</magH>
 			<magK errorminus="0.018" errorplus="0.018">9.334</magK>
-			<temperature errorminus="32" errorplus="32">6259</temperature>
-			<age>2.2082</age>
-			<metallicity>0.26</metallicity>
+			<temperature errorminus="15" errorplus="15">6310</temperature>
+			<age errorminus="0.100" errorplus="0.100">1.770</age>
+			<metallicity errorminus="0.04" errorplus="0.04">0.32</metallicity>
 			<planet>
 				<name>HAT-P-7 b</name>
 				<name>HAT-P-7 A b</name>
@@ -39,9 +39,10 @@
 				<semimajoraxis>0.0379</semimajoraxis>
 				<eccentricity>0.0</eccentricity>
 				<inclination>83.111</inclination>
-				<description>The star HAT-P-7 is located in the constellation Cygnus and in the field of view of the Kepler spacecraft. Measurements of the Rossiter-McLaughlin effect suggest that this planet is in a retrograde orbit. Retrograde orbits are difficult to explain with standard disk migration. Planet-planet scattering or the Kozei effect are able to produce retrograde orbits.</description>
+				<spinorbitalignment errorminus="13" errorplus="14">157</spinorbitalignment>
+				<description>The star HAT-P-7 is located in the constellation Cygnus and in the field of view of the Kepler spacecraft. Measurements of the Rossiter-McLaughlin effect combined with determination of the stellar equator suggest an inclination of 120 degrees to the stellar equator. Retrograde orbits are difficult to explain with standard disk migration. Planet-planet scattering or the Kozei effect are able to produce retrograde orbits.</description>
 				<discoverymethod>transit</discoverymethod>
-				<lastupdate>13/01/24</lastupdate>
+				<lastupdate>15/05/24</lastupdate>
 				<discoveryyear>2008</discoveryyear>
 				<transittime errorminus="0.00064" errorplus="0.00064" unit="BJD">2454342.42691</transittime>
 				<istransiting>1</istransiting>

--- a/systems/Kepler-25.xml
+++ b/systems/Kepler-25.xml
@@ -7,8 +7,8 @@
 		<name>Kepler-25</name>
 		<name>KOI-244</name>
 		<name>KIC 4349452</name>
-		<mass>1.22</mass>
-		<radius>1.36</radius>
+		<mass errorminus="0.03" errorplus="0.03">1.26</mass>
+		<radius errorminus="0.01" errorplus="0.01">1.34</radius>
 		<magB errorminus="0.07" errorplus="0.07">11.32</magB>
 		<magV errorminus="0.06" errorplus="0.06">10.77</magV>
 		<magR errorminus="0.021" errorplus="0.021">10.598</magR>
@@ -16,7 +16,9 @@
 		<magH errorminus="0.020" errorplus="0.020">9.532</magH>
 		<magK errorminus="0.017" errorplus="0.017">9.493</magK>
 		<spectraltype>F</spectraltype>
-		<temperature>6190.0</temperature>
+		<temperature errorminus="27" errorplus="27">6354</temperature>
+		<age errorminus="0.300" errorplus="0.300">2.750</age>
+		<metallicity errorminus="0.03" errorplus="0.03">0.11</metallicity>
 		<planet>
 			<name>Kepler-25 b</name>
 			<name>KIC 4349452 b</name>
@@ -44,9 +46,10 @@
 			<period>12.72</period>
 			<semimajoraxis>0.110</semimajoraxis>
 			<transittime errorminus="0.0008" errorplus="0.0008" unit="BJD">2454986.0871</transittime>
-			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-25 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet.</description>
+			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-25 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet. The orbit is aligned at 26.9 degrees from the stellar equator.</description>
+			<spinorbitalignment errorminus="7.1" errorplus="7.1">9.4</spinorbitalignment>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>12/08/06</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2012</discoveryyear>
 			<temperature>959.7</temperature>
 			<istransiting>1</istransiting>


### PR DESCRIPTION
* Spin-orbit alignment (lambda) information for Kepler-25c and HAT-P-7b
* Updated stellar parameters

Benomar et al. (2014) http://adsabs.harvard.edu/abs/2014PASJ...66...94B

For this change I used the sky-projected misalignment (λ) rather than the three-dimensional misalignment (ψ) as this seems to be what is implied by the definition of the `<spinorbitalignment>` element in the README file.

Closes #293