### PR TITLE
Update RAFT planets

### DIFF
--- a/systems/HD 110014.xml
+++ b/systems/HD 110014.xml
@@ -4,23 +4,39 @@
 	<declination>-07 59 44</declination>
 	<distance>90</distance>
 	<star>
-		<mass>2.17</mass>
+		<mass>2.09</mass>
 		<radius>20.9</radius>
 		<magV>4.66</magV>
 		<magB>5.904</magB>
-		<metallicity>0.19</metallicity>
+		<metallicity>0.14</metallicity>
 		<spectraltype>K2III</spectraltype>
 		<planet>
 			<name>HD 110014 b</name>
 			<list>Confirmed planets</list>
-			<mass>11.09</mass>
-			<period>835.477</period>
-			<semimajoraxis>2.14</semimajoraxis>
-			<eccentricity>0.462</eccentricity>
+			<mass errorminus="1.0" errorplus="1.0">10.7</mass>
+			<period errorminus="21.5" errorplus="21.5">882.6</period>
+			<semimajoraxis errorminus="0.04" errorplus="0.04">2.31</semimajoraxis>
+			<eccentricity errorminus="0.1" errorplus="0.1">0.26</eccentricity>
+			<periastron errorminus="15.5" errorplus="15.5">47.72</periastron>
+			<periastrontime errorminus="50.2" errorplus="50.2">2453739.4</periastrontime>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>09/07/31</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2009</discoveryyear>
-			<temperature>603.9</temperature>
+			<description>HD 110014 b is a planet in an eccentric orbit around a red giant star.</description>
+		</planet>
+		<planet>
+			<name>HD 110014 c</name>
+			<list>Confirmed planets</list>
+			<mass errorminus="0.4" errorplus="0.4">3.1</mass>
+			<period errorminus="0.9" errorplus="0.9">130.0</period>
+			<semimajoraxis errorminus="0.003" errorplus="0.003">0.64</semimajoraxis>
+			<eccentricity errorminus="0.2" errorplus="0.2">0.44</eccentricity>
+			<periastron errorminus="19.9" errorplus="19.9">307.6</periastron>
+			<periastrontime errorminus="3.78" errorplus="3.78">2454031.3</periastrontime>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>15/05/24</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+			<description>The planet HD 110014 c was discovered by the Reanalysis of Archival FEROS specTra (RAFT) program. The outer planet HD 110014 b was already known.</description>
 		</planet>
 		<name>HD 110014</name>
 		<temperature>4445.0</temperature>

--- a/systems/HD 11977.xml
+++ b/systems/HD 11977.xml
@@ -4,26 +4,28 @@
 	<declination>-67 38 50</declination>
 	<distance>66.5</distance>
 	<star>
-		<mass>1.91</mass>
+		<mass>2.31</mass>
 		<radius>13</radius>
 		<magV>4.7</magV>
 		<magB>5.614</magB>
 		<magJ errorminus="0.01" errorplus="0.01">3.046</magJ>
 		<magH errorminus="0.01" errorplus="0.01">2.594</magH>
 		<magK errorminus="0.01" errorplus="0.01">2.486</magK>
-		<metallicity>-0.21</metallicity>
-		<spectraltype>G8.5 III</spectraltype>
+		<metallicity>-0.16</metallicity>
+		<spectraltype>G5 III</spectraltype>
 		<planet>
 			<name>HD 11977 b</name>
 			<list>Confirmed planets</list>
-			<mass>6.54</mass>
-			<period>711</period>
-			<semimajoraxis>1.93</semimajoraxis>
-			<eccentricity>0.4</eccentricity>
+			<mass errorminus="0.2" errorplus="0.2">6.5</mass>
+			<period errorminus="2.4" errorplus="2.4">621.6</period>
+			<semimajoraxis errorminus="0.005" errorplus="0.005">1.89</semimajoraxis>
+			<eccentricity errorminus="0.03" errorplus="0.03">0.3</eccentricity>
+			<periastron errorminus="5.8" errorplus="5.8">35.5</periastron>
+			<periastrontime errorminus="10" errorplus="10">2452906.6</periastrontime>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>10/12/29</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2005</discoveryyear>
-			<temperature>563.4</temperature>
+			<description>HD 11977 b was the first planet confirmed to be orbiting an intermediate-mass star.</description>
 		</planet>
 		<name>HD 11977</name>
 		<temperature>4975.0</temperature>

--- a/systems/HD 122430.xml
+++ b/systems/HD 122430.xml
@@ -4,26 +4,27 @@
 	<declination>-27 25 47</declination>
 	<distance>135</distance>
 	<star>
-		<mass>1.39</mass>
+		<mass>1.68</mass>
 		<radius>22.9</radius>
 		<magV>5.48</magV>
 		<magB>6.827</magB>
 		<magJ errorminus="0.272" errorplus="0.272">3.080</magJ>
 		<magH errorminus="0.216" errorplus="0.216">2.373</magH>
 		<magK errorminus="0.294" errorplus="0.294">2.261</magK>
-		<metallicity>-0.05</metallicity>
+		<metallicity>-0.09</metallicity>
 		<spectraltype>K3III</spectraltype>
 		<planet>
 			<name>HD 122430 b</name>
-			<list>Confirmed planets</list>
+			<list>Controversial</list>
 			<mass>3.71</mass>
 			<period>344.95</period>
 			<semimajoraxis>1.02</semimajoraxis>
 			<eccentricity>0.68</eccentricity>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>10/12/22</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2003</discoveryyear>
 			<temperature>868.8</temperature>
+			<description>The planet candidate HD 122430 b was not confirmed in follow-up measurements (Soto et al. 2015)</description>
 		</planet>
 		<name>HD 122430</name>
 		<temperature>4300.0</temperature>

--- a/systems/HD 47536.xml
+++ b/systems/HD 47536.xml
@@ -4,35 +4,38 @@
 	<declination>-32 20 23</declination>
 	<distance>121.36</distance>
 	<star>
-		<mass>0.94</mass>
+		<mass>0.99</mass>
 		<radius>23.47</radius>
 		<magV>5.25</magV>
 		<magJ errorminus="0.27" errorplus="0.27">3.179</magJ>
 		<magH errorminus="0.21" errorplus="0.21">2.471</magH>
 		<magK errorminus="0.252" errorplus="0.252">2.383</magK>
 		<magB errorminus="0.01" errorplus="0.01">6.43</magB>
-		<metallicity>-0.68</metallicity>
+		<metallicity>-0.65</metallicity>
 		<spectraltype>K1 III</spectraltype>
 		<planet>
 			<name>HD 47536 b</name>
 			<list>Confirmed planets</list>
-			<mass>5</mass>
-			<period>430</period>
-			<semimajoraxis>1.61</semimajoraxis>
-			<eccentricity>0.2</eccentricity>
+			<mass errorminus="0.4" errorplus="0.4">4.0</mass>
+			<period errorminus="2.6" errorplus="2.6">434.9</period>
+			<semimajoraxis errorminus="0.005" errorplus="0.005">1.12</semimajoraxis>
+			<eccentricity errorminus="0.1" errorplus="0.1">0.3</eccentricity>
+			<periastron errorminus="17.3" errorplus="17.3">268.6</periastron>
+			<periastrontime errorminus="30" errorplus="30">2453040.8</periastrontime>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>10/12/21</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2003</discoveryyear>
-			<temperature>735.5</temperature>
+			<description>The planet HD 47536 b orbits a metal-poor red giant star.</description>
 		</planet>
 		<planet>
 			<name>HD 47536 c</name>
-			<list>Confirmed planets</list>
+			<list>Controversial</list>
 			<mass>7</mass>
 			<period>2500</period>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>10/12/21</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2007</discoveryyear>
+			<description>The planet candidate HD 47536 c was not confirmed in follow-up measurements (Soto et al. 2015).</description>
 		</planet>
 		<name>HD 47536</name>
 		<temperature>4380.0</temperature>

--- a/systems/HD 70573.xml
+++ b/systems/HD 70573.xml
@@ -15,15 +15,16 @@
 		<spectraltype>G1-1.5V</spectraltype>
 		<planet>
 			<name>HD 70573 b</name>
-			<list>Confirmed planets</list>
+			<list>Controversial</list>
 			<mass>6.1</mass>
 			<period>851.8</period>
 			<semimajoraxis>1.76</semimajoraxis>
 			<eccentricity>0.4</eccentricity>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>08/01/18</lastupdate>
+			<lastupdate>15/05/24</lastupdate>
 			<discoveryyear>2007</discoveryyear>
 			<temperature>167.4</temperature>
+			<description>The planet candidate HD 70573 b was not confirmed in follow-up measurements (Soto et al. 2015).</description>
 		</planet>
 		<name>HD 70573</name>
 		<temperature>5737.0</temperature>


### PR DESCRIPTION
* New planet HD 110014 c
* Non-confirmations of HD 47536 c, HD 70573 b, HD 122430 b
* Orbital elements updates for confirmed planets

Soto et al. (2015) http://arxiv.org/abs/1505.04796

Closes #588