### PR TITLE
Photometric Kepler eccentricities part 1

### DIFF
--- a/systems/KOI-285.xml
+++ b/systems/KOI-285.xml
@@ -8,30 +8,32 @@
 		<name>KOI-285</name>
 		<name>Kepler-92</name>
 		<name>KIC 6196457</name>
-		<mass errorminus="0.46" errorplus="0.34">1.17</mass>
-		<radius errorminus="0.19" errorplus="0.19">1.53</radius>
+		<mass errorminus="0.030" errorplus="0.020">1.209</mass>
+		<radius errorminus="0.013" errorplus="0.011">1.719</radius>
 		<magB errorminus="0.23" errorplus="0.23">12.50</magB>
 		<magV errorminus="0.15" errorplus="0.15">11.67</magV>
 		<magJ errorminus="0.023" errorplus="0.023">10.747</magJ>
 		<magH errorminus="0.021" errorplus="0.021">10.470</magH>
 		<magK errorminus="0.018" errorplus="0.018">10.403</magK>
-		<temperature errorminus="50.00" errorplus="50.00">5883.00</temperature>
-		<age errorminus="1.1000" errorplus="1.1000">5.2000</age>
+		<temperature errorminus="50" errorplus="50">5883</temperature>
+		<age errorminus="1.1" errorplus="1.1">5.2</age>
 		<planet>
 			<name>KOI-285 b</name>
 			<name>KOI-285.01</name>
 			<name>Kepler-92 b</name>
 			<name>KIC 6196457 b</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="0.0437343285" errorplus="0.0437343285">0.202310599</mass>
-			<radius errorminus="0.039" errorplus="0.039">0.314</radius>
-			<period>13.749</period>
+			<mass upperlimit="0.162" />
+			<radius errorminus="0.012" errorplus="0.012">0.326</radius>
+			<period errorminus="0.000075" errorplus="0.000075">13.748933</period>
+			<transittime errorminus="0.0130786" errorplus="0.0130786" unit="BJD">2455008.9263306</transittime>
+			<eccentricity errorminus="0.17" errorplus="0.1">0.17</eccentricity>
 			<temperature>934</temperature>
 			<semimajoraxis>0.11800</semimajoraxis>
 			<description>This planet was discovered by the Kepler spacecraft. The planet is part of a multiplanetary system. Its planetary nature has been confirmed using transit timing variations which arise because the planets in one system pull on each other and slightly alter the transit times.</description>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
-			<lastupdate>14/03/26</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 		</planet>
 		<planet>
@@ -40,28 +42,34 @@
 			<name>Kepler-92 c</name>
 			<name>KIC 6196457 c</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="0.00566343823" errorplus="0.00566343823">0.0191927629</mass>
-			<radius errorminus="0.029" errorplus="0.029">0.233</radius>
-			<period>26.723</period>
+			<mass upperlimit="0.0890" />
+			<radius errorminus="0.0047" errorplus="0.0047">0.2190</radius>
+			<period errorminus="0.00019" errorplus="0.00019">26.72311</period>
+			<transittime errorminus="0.0184593" errorplus="0.0184593" unit="BJD">2454986.4408417</transittime>
+			<eccentricity errorminus="0.04" errorplus="0.22">0.04</eccentricity>
 			<temperature>748</temperature>
 			<semimajoraxis>0.18400</semimajoraxis>
 			<description>This planet was discovered by the Kepler spacecraft. The planet is part of a multiplanetary system. Its planetary nature has been confirmed using transit timing variations which arise because the planets in one system pull on each other and slightly alter the transit times.</description>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
-			<lastupdate>14/03/26</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 		</planet>
 		<planet>
+			<name>KOI-285 d</name>
 			<name>KOI-285.03</name>
-			<radius errorminus="0.02187" errorplus="0.02187">0.16768</radius>
-			<period errorminus="7.40000e-04" errorplus="7.40000e-04">49.358990000000</period>
-			<transittime errorminus="0.0073000" errorplus="0.0073000">2454967.2716000</transittime>
+			<name>Kepler-92 d</name>
+			<name>KIC 6196457 d</name>
+			<radius errorminus="0.0050" errorplus="0.0050">0.1844</radius>
+			<period errorminus="0.0024" errorplus="0.0024">49.3568</period>
+			<eccentricity errorminus="0.04" errorplus="0.34">0.07</eccentricity>
+			<transittime errorminus="0.0073" errorplus="0.0073" unit="BJD">2454967.2716</transittime>
 			<semimajoraxis>0.2780000</semimajoraxis>
 			<temperature>608.0</temperature>
-			<list>Kepler Objects of Interest</list>
+			<list>Confirmed planets</list>
 			<description>This is a Kepler Object of Interest from the Q1-Q12 dataset. It has been flagged as a possible transit event but has not been confirmed to be a planet yet.</description>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>14/02/25</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2014</discoveryyear>
 			<istransiting>1</istransiting>
 		</planet>

--- a/systems/Kepler-23.xml
+++ b/systems/Kepler-23.xml
@@ -15,7 +15,7 @@
 		<name>KOI-168</name>
 		<name>KIC 11512246</name>
 		<temperature errorminus="100" errorplus="100">5828</temperature>
-		<radius errorminus=".048" errorplus="0.048">1.548</radius>
+		<radius errorminus="0.048" errorplus="0.048">1.548</radius>
 		<mass errorminus="0.1300" errorplus="0.1300">1.1900</mass>
 		<planet>
 			<name>Kepler-23 c</name>
@@ -24,12 +24,13 @@
 			<name>KIC 11512246 c</name>
 			<name>KIC 11512246.01</name>
 			<radius errorminus="0.03007" errorplus="0.03007">0.34447</radius>
-			<period errorminus=".000037" errorplus="0.000037">10.742371</period>
+			<period errorminus="0.000037" errorplus="0.000037">10.742371</period>
 			<transittime errorminus="0.0021000" errorplus="0.0021000">2454966.2860300</transittime>
+			<eccentricity errorminus="0.02" errorplus="0.39">0.02</eccentricity>
 			<list>Confirmed planets</list>
 			<description>Kepler-23 c has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-23 c are still unknown, the object is highly unlikely to be a false positive.</description>
 			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/26</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
 		</planet>
@@ -40,12 +41,13 @@
 			<name>KIC 11512246 d</name>
 			<name>KIC 11512246.02</name>
 			<radius errorminus="0.00820" errorplus="0.00820">0.20049</radius>
-			<period errorminus=".000104" errorplus="0.000104">15.274299</period>
+			<period errorminus="0.000104" errorplus="0.000104">15.274299</period>
 			<transittime errorminus="0.0038700" errorplus="0.0038700">2454980.5825300</transittime>
+			<eccentricity errorminus="0.08" errorplus="0.24">0.08</eccentricity>
 			<list>Confirmed planets</list>
 			<description>Kepler-23 d has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-23 d are still unknown, the object is highly unlikely to be a false positive.</description>
 			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/26</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
 		</planet>
@@ -56,12 +58,13 @@
 			<name>KIC 11512246 b</name>
 			<name>KIC 11512246.03</name>
 			<radius errorminus="0.01458" errorplus="0.01458">0.15401</radius>
-			<period errorminus=".000075" errorplus="0.000075">7.107163</period>
+			<period errorminus="0.000075" errorplus="0.000075">7.107163</period>
 			<transittime errorminus="0.0066100" errorplus="0.0066100">2454971.3128400</transittime>
+			<eccentricity errorminus="0.06" errorplus="0.26">0.06</eccentricity>
 			<list>Confirmed planets</list>
 			<description>Kepler-23 b has been discovered by the Kepler spacecraft and was originally classified as a planet candidate. A new statistical analysis led by a team at NASA Ames Research Center has validated the planet with more than 99 percent confidence. Although many parameters of Kepler-23 b are still unknown, the object is highly unlikely to be a false positive.</description>
 			<discoveryyear>2014</discoveryyear>
-			<lastupdate>14/02/26</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
 		</planet>

--- a/systems/Kepler-25.xml
+++ b/systems/Kepler-25.xml
@@ -25,13 +25,14 @@
 			<name>KOI-244.02</name>
 			<name>KOI-244 b</name>
 			<list>Confirmed planets</list>
-			<radius>0.2369387</radius>
-			<period>6.238</period>
+			<radius errorminus="0.0033" errorplus="0.0033">0.2411</radius>
+			<period errorminus="0.0000033" errorplus="0.0000033">6.2385369</period>
 			<semimajoraxis>0.068</semimajoraxis>
 			<transittime errorminus="0.0021" errorplus="0.0021" unit="BJD">2454973.5126</transittime>
+			<eccentricity errorminus="0.05" errorplus="0.11">0.05</eccentricity>
 			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-25 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet.</description>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>12/08/06</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2012</discoveryyear>
 			<temperature>1220.6</temperature>
 			<istransiting>1</istransiting>
@@ -42,14 +43,15 @@
 			<name>KOI-244.01</name>
 			<name>KOI-244 c</name>
 			<list>Confirmed planets</list>
-			<radius>0.410086</radius>
-			<period>12.72</period>
+			<radius errorminus="0.0054" errorplus="0.0054">0.4598</radius>
+			<period errorminus="0.0000035" errorplus="0.0000035">12.7203678</period>
 			<semimajoraxis>0.110</semimajoraxis>
 			<transittime errorminus="0.0008" errorplus="0.0008" unit="BJD">2454986.0871</transittime>
+			<eccentricity errorminus="0.01" errorplus="0.07">0.01</eccentricity>
 			<description>This planet candidate was discovered with the Kepler spacecraft. Its host star gets periodically fainter whenever the planet is in front of the star. Because there are multiple phenomena that can create a signal that looks similar to a planetary transit, the candidates have to be confirmed with another method. For Kepler-25 the planetary nature of the companions has been confirmed by transit timing variations, caused by other planets in the system, and a stability analysis. However, the mass of the planets is not well constrained yet. The orbit is aligned at 26.9 degrees from the stellar equator.</description>
 			<spinorbitalignment errorminus="7.1" errorplus="7.1">9.4</spinorbitalignment>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/05/24</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2012</discoveryyear>
 			<temperature>959.7</temperature>
 			<istransiting>1</istransiting>

--- a/systems/Kepler-37.xml
+++ b/systems/Kepler-37.xml
@@ -14,10 +14,10 @@
 		<name>KOI-245</name>
 		<name>KIC 8478994</name>
 		<name>UGA-1785</name>
-		<mass>0.803</mass>
-		<radius>0.770</radius>
-		<metallicity>-0.32</metallicity>
-		<temperature>5417</temperature>
+		<mass errorminus="0.068" errorplus="0.068">0.803</mass>
+		<radius errorminus="0.026" errorplus="0.026">0.770</radius>
+		<metallicity errorminus="0.07" errorplus="0.07">-0.32</metallicity>
+		<temperature errorminus="75" errorplus="75">5417</temperature>
 		<age>6</age>
 		<planet>
 			<name>Kepler-37 b</name>
@@ -26,14 +26,14 @@
 			<name>KIC 8478994 b</name>
 			<name>UGA-1785 b</name>
 			<list>Confirmed planets</list>
-			<radius>0.02761247</radius>
-			<period>13.367308</period>
-			<semimajoraxis>0.1003</semimajoraxis>
-			<eccentricity>0.715</eccentricity>
-			<inclination>88.63</inclination>
+			<radius errorminus="0.0065" errorplus="0.0047">0.0270</radius>
+			<period errorminus="0.000085" errorplus="0.000058">13.367308</period>
+			<semimajoraxis errorminus="0.0011" errorplus="0.0008">0.1003</semimajoraxis>
+			<eccentricity errorminus="0.08" errorplus="0.21">0.08</eccentricity>
+			<inclination errorminus="0.53" errorplus="0.30">88.63</inclination>
 			<transittime errorminus="0.00089" errorplus="0.00034" unit="BJD">2455017.03271</transittime>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/04/17</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<description>Kepler-37 b is a tiny planet, about the size of our Moon. Due to the high irradiation it has probably a rocky surface with no atmosphere or water, similar than Mercury. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
 			<istransiting>1</istransiting>
@@ -45,14 +45,14 @@
 			<name>KIC 8478994 c</name>
 			<name>UGA-1785 c</name>
 			<list>Confirmed planets</list>
-			<radius>0.067618678</radius>
-			<period>21.301886</period>
-			<semimajoraxis>0.1368</semimajoraxis>
-			<eccentricity>0.098</eccentricity>
-			<inclination>89.07</inclination>
+			<radius errorminus="0.0074" errorplus="0.0058">0.0662</radius>
+			<period errorminus="0.000044" errorplus="0.000046">21.301886</period>
+			<semimajoraxis errorminus="0.0014" errorplus="0.0011">0.1368</semimajoraxis>
+			<eccentricity errorminus="0.09" errorplus="0.18">0.09</eccentricity>
+			<inclination errorminus="0.33" errorplus="0.19">89.07</inclination>
 			<transittime errorminus="0.00078" errorplus="0.00036" unit="BJD">2455024.83816</transittime>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/04/17</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<description>Kepler-37 is a three planet system discovered by Kepler. The planet Kepler-37 c is about three quaters the size of Earth. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>
 			<istransiting>1</istransiting>
@@ -65,12 +65,12 @@
 			<name>UGA-1785 d</name>
 			<list>Confirmed planets</list>
 			<radius>0.181349</radius>
-			<period>39.792187</period>
-			<semimajoraxis>0.2076</semimajoraxis>
-			<eccentricity>0.1024</eccentricity>
-			<inclination>89.335</inclination>
+			<period errorminus="0.000043" errorplus="0.000040">39.792187</period>
+			<semimajoraxis errorminus="0.0022" errorplus="0.0016">0.2076</semimajoraxis>
+			<eccentricity errorminus="0.1" errorplus="0.07">0.15</eccentricity>
+			<inclination errorminus="0.047" errorplus="0.043">89.335</inclination>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/04/17</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<transittime errorminus="0.00049" errorplus="0.00043" unit="BJD">2455008.24979</transittime>
 			<discoveryyear>2013</discoveryyear>
 			<description>Kepler-37 d is the outermost planet in a three planet system discovered by Kepler. It is twice as big as Earth and therefore the largest known planet in the system. NASA has given the planetary system the alternative identifier UGA-1785 in honor of the University of Georgia.</description>

--- a/systems/Kepler-65.xml
+++ b/systems/Kepler-65.xml
@@ -24,9 +24,10 @@
 			<name>KOI-85 b</name>
 			<name>KIC 5866724 b</name>
 			<list>Confirmed planets</list>
-			<radius>0.12940502</radius>
-			<period>2.154910</period>
+			<radius errorminus="0.0015" errorplus="0.0015">0.1257</radius>
+			<period errorminus="0.0000025" errorplus="0.0000025">2.1549156</period>
 			<transittime errorminus="0.0013" errorplus="0.0013" unit="BJD">2454966.4990</transittime>
+			<eccentricity errorminus="0.02" errorplus="0.17">0.02</eccentricity>
 			<description>This object was found by the Kepler mission. It is very likely that the transit signals are caused by planets because of statistical arguments, the fact that the system seems to host three planets and significant transit timing variations. The outer two planets are near a 7:5 commensurability.</description>
 			<semimajoraxis>0.035</semimajoraxis>
 			<inclination>81</inclination>
@@ -41,9 +42,10 @@
 			<name>KOI-85 c</name>
 			<name>KIC 5866724 c</name>
 			<list>Confirmed planets</list>
-			<radius>0.2351161</radius>
-			<period>5.859944</period>
+			<radius errorminus="0.0029" errorplus="0.0029">0.2294</radius>
+			<period errorminus="0.0000023" errorplus="0.0000023">5.8599408</period>
 			<transittime errorminus="0.0003" errorplus="0.0003" unit="BJD">2454965.0391</transittime>
+			<eccentricity errorminus="0.08" errorplus="0.12">0.08</eccentricity>
 			<description>This object was found by the Kepler mission. It is very likely that the transit signals are caused by planets because of statistical arguments, the fact that the system seems to host three planets and significant transit timing variations. The planet Kepler-65 c is near a 7:5 commensurability with the planet Kepler-65 d.</description>
 			<semimajoraxis>0.068</semimajoraxis>
 			<inclination>81</inclination>
@@ -58,9 +60,10 @@
 			<name>KOI-85 d</name>
 			<name>KIC 5866724 d</name>
 			<list>Confirmed planets</list>
-			<radius>0.1385180</radius>
-			<period>8.13123</period>
+			<radius errorminus="0.0036" errorplus="0.0036">0.1344</radius>
+			<period errorminus="0.000021" errorplus="0.000021">8.131231</period>
 			<transittime errorminus="0.0016" errorplus="0.0016" unit="BJD">2454970.9905</transittime>
+			<eccentricity errorminus="0.1" errorplus="0.23">0.1</eccentricity>
 			<description>This object was found by the Kepler mission. It is very likely that the transit signals are caused by planets because of statistical arguments, the fact that the system seems to host three planets and significant transit timing variations. Only an upper mass limit is known for this system (10 Earth masses). It is near a 7:5 commensurability with the planet Kepler-65 c.</description>
 			<semimajoraxis>0.084</semimajoraxis>
 			<inclination>81</inclination>

--- a/systems/Kepler-68.xml
+++ b/systems/Kepler-68.xml
@@ -2,22 +2,22 @@
 	<name>Kepler-68</name>
 	<rightascension>19 24 07</rightascension>
 	<declination>+49 02 25</declination>
-	<distance>135</distance>
+	<distance errorminus="10" errorplus="10">135</distance>
 	<star>
 		<name>Kepler-68</name>
 		<name>KOI-246</name>
 		<name>KIC 11295426</name>
 		<name>2MASS J19240775+4902249</name>
-		<mass>1.079</mass>
-		<radius>1.243</radius>
-		<temperature>5793</temperature>
+		<mass errorminus="0.051" errorplus="0.051">1.079</mass>
+		<radius errorminus="0.019" errorplus="0.019">1.243</radius>
+		<temperature errorminus="74" errorplus="74">5793</temperature>
 		<magV errorminus="0.001" errorplus="0.001">9.997</magV>
 		<magB errorminus="0.04" errorplus="0.04">10.73</magB>
 		<magJ errorminus="0.046" errorplus="0.046">8.975</magJ>
 		<magH errorminus="0.029" errorplus="0.029">8.662</magH>
 		<magK errorminus="0.022" errorplus="0.022">8.588</magK>
-		<age>6.3</age>
-		<metallicity>0.12</metallicity>
+		<age errorminus="1.7" errorplus="1.7">6.3</age>
+		<metallicity errorminus="0.074" errorplus="0.074">0.12</metallicity>
 		<spectraltype>G</spectraltype>
 		<planet>
 			<name>Kepler-68 b</name>
@@ -26,16 +26,16 @@
 			<name>KOI-246.01</name>
 			<name>KOI-246 b</name>
 			<list>Confirmed planets</list>
-			<mass>0.02610931</mass>
-			<radius>0.2105109</radius>
-			<temperature>1280</temperature>
-			<period>5.398763</period>
-			<semimajoraxis>0.06170</semimajoraxis>
-			<eccentricity>0.0</eccentricity>
-			<inclination>87.60</inclination>
+			<mass errorminus="0.007" errorplus="0.008">0.026</mass>
+			<radius errorminus="0.008" errorplus="0.005">0.206</radius>
+			<temperature errorminus="90" errorplus="90">1280</temperature>
+			<period errorminus="0.000004" errorplus="0.000004">5.398763</period>
+			<semimajoraxis errorminus="0.00056" errorplus="0.00056">0.06170</semimajoraxis>
+			<eccentricity errorminus="0.02" errorplus="0.13">0.02</eccentricity>
+			<inclination errorminus="0.90" errorplus="0.90">87.60</inclination>
 			<transittime errorminus="0.00042" errorplus="0.00042" unit="BJD">2455006.85729</transittime>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/02/13</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<description>The inner two planets in the Kepler-68 system are transiting. The outer planet was discovered by radial velocity follow-up observation. Kepler-68 b has a density intermediate between that of ice giants and Earth.</description>
 			<istransiting>1</istransiting>
@@ -47,14 +47,14 @@
 			<name>KOI-246.02</name>
 			<name>KOI-246 c</name>
 			<list>Confirmed planets</list>
-			<mass>0.01509936</mass>
-			<radius>0.0868471</radius>
-			<period>9.605085</period>
-			<semimajoraxis>0.09059</semimajoraxis>
-			<inclination>86.93</inclination>
+			<mass errorminus="0.011" errorplus="0.008">0.015</mass>
+			<radius errorminus="0.0037" errorplus="0.0033">0.0850</radius>
+			<period errorminus="0.000072" errorplus="0.000072">9.605085</period>
+			<semimajoraxis errorminus="0.00082" errorplus="0.00082">0.09059</semimajoraxis>
+			<inclination errorminus="0.41" errorplus="0.41">86.93</inclination>
 			<transittime errorminus="0.0041" errorplus="0.0041" unit="BJD">2454969.3805</transittime>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/02/13</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<description>The inner two planets in the Kepler-68 system are transiting. The outer planet was discovered by radial velocity follow-up observation. Kepler-68 c is Earth-sized.</description>
 			<istransiting>1</istransiting>
@@ -66,12 +66,12 @@
 			<name>KOI-246.20</name>
 			<name>KOI-246 d</name>
 			<list>Confirmed planets</list>
-			<mass>0.947</mass>
-			<period>580</period>
-			<semimajoraxis>1.40</semimajoraxis>
-			<eccentricity>0.18</eccentricity>
+			<mass errorminus="0.035" errorplus="0.035">0.947</mass>
+			<period errorminus="15" errorplus="15">580</period>
+			<semimajoraxis errorminus="0.03" errorplus="0.03">1.40</semimajoraxis>
+			<eccentricity errorminus="0.05" errorplus="0.05">0.18</eccentricity>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>13/02/13</lastupdate>
+			<lastupdate>15/06/09</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<description>The inner two planets in the Kepler-68 system are transiting. The outer planet, Kepler-68 d, was discovered by radial velocity follow-up observation. The mass is therefor a lower limit.</description>
 		</planet>


### PR DESCRIPTION
Updates for #586 

* Kepler-10: leaving with RV orbits, no change
* Kepler-23: updated b,c,d
* Kepler-25: updated b,c
* Kepler-37: updated b,c,d + fixed missing error bars
* Kepler-65: updated b,c
* Kepler-68: updated b + fixed missing error bars. Eccentricity determination for c unreliable so omitted
* Kepler-92: planet d confirmed, updated b,c. Fixed missing transit times