### PR TITLE
allow spectraltype white dwarf

### DIFF
--- a/oec.xsd
+++ b/oec.xsd
@@ -146,7 +146,7 @@
 	<!-- Spectraltype Definition -->
 	<xs:simpleType name="spectraltypedef">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="[OBAFGKMLTYRNSsDC].*"/>
+			<xs:pattern value="[OBAFGKMLTYRNSsDCW].*"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<!-- Right Ascension Definition -->


### PR DESCRIPTION
added "W" to allow the spectraltype white dwarf (WD)
HU Aqr has such a spectraltype definition