### PR TITLE
Added Kepler-453 designation to KIC 9632895

### DIFF
--- a/systems/KIC 9632895.xml
+++ b/systems/KIC 9632895.xml
@@ -4,6 +4,9 @@
 	<declination>+46 22 42</declination>
 	<distance>500</distance>
 	<binary>
+		<name>KIC 9632895</name>
+		<name>KOI-1451</name>
+		<name>Kepler-453</name>
 		<magJ errorminus="0.022" errorplus="0.022">12.349</magJ>
 		<magH errorminus="0.019" errorplus="0.019">11.970</magH>
 		<magK errorminus="0.020" errorplus="0.020">11.920</magK>
@@ -15,6 +18,7 @@
 		<star>
 			<name>KIC 9632895 A</name>
 			<name>KOI-1451 A</name>
+			<name>Kepler-453 A</name>
 			<mass errorminus="0.01" errorplus="0.01">0.934</mass>
 			<radius errorminus="0.011" errorplus="0.011">0.833</radius>
 			<temperature errorminus="100" errorplus="100">5527</temperature>
@@ -25,6 +29,7 @@
 			<name>KIC 9632895 B</name>
 			<name>KOI-1451.01</name>
 			<name>KOI-1451 B</name>
+			<name>Kepler-453 B</name>
 			<mass errorminus="0.002" errorplus="0.002">0.1938</mass>
 			<radius errorminus="0.0014" errorplus="0.0014">0.2143</radius>
 			<temperature errorminus="100" errorplus="100">3309</temperature>
@@ -34,6 +39,8 @@
 			<name>KIC 9632895 b</name>
 			<name>KIC 9632895 (AB) b</name>
 			<name>KOI-1451 (AB) b</name>
+			<name>Kepler-453 b</name>
+			<name>Kepler-453 (AB) b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.050331" errorplus="0.050331">0.019503</mass>
 			<radius errorminus="0.003190" errorplus="0.003190">0.561818</radius>


### PR DESCRIPTION
Per [NASA Exoplanet Archive](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler+453+b&type=CONFIRMED_PLANET).

While that page also gives KOI-1451.01 as an alternate designation for the planet, the [KOI Overview](http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=K01451.01&type=KEPLER_CANDIDATE) indicates that this designation is for the 27-day orbit, i.e. it represents the secondary star. I'm therefore leaving KOI-1451.01 on the star KIC 9632895 B.