### PR TITLE
Add K2 designation to HAT-P-56

### DIFF
--- a/systems/HAT-P-56.xml
+++ b/systems/HAT-P-56.xml
@@ -9,6 +9,7 @@
 		<name>2MASS 06432353+2715082</name>
 		<name>EPIC 202126852</name>
 		<name>HD 262389</name>
+		<name>K2-20</name>
 		<mass errorminus="0.036" errorplus="0.036">1.296</mass>
 		<radius errorminus="0.030" errorplus="0.030">1.428</radius>
 		<temperature errorminus="50" errorplus="50">6566</temperature>
@@ -25,6 +26,7 @@
 			<name>2MASS 06432353+2715082 b</name>
 			<name>EPIC 202126852 b</name>
 			<name>HD 262389 b</name>
+			<name>K2-20 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.25" errorplus="0.25">2.18</mass>
 			<radius errorminus="0.040" errorplus="0.040">1.466</radius>


### PR DESCRIPTION
Source: NASA Exoplanet Archive (K2 names table)
http://exoplanetarchive.ipac.caltech.edu./cgi-bin/TblView/nph-tblView?app=ExoTbls&config=k2names