### PR TITLE
Support component attribute on periastron tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following table shows all the possible tags in the Open Exoplanet Catalogue.
 | `separation`	 	| `binary`, `planet` | Projected separation of planet from its host, or if child of `binary` the projected separation from one component to the other. This tag can occur multiple times with different units. It is different from the tag `semimajoraxis` as it does not imply a specific orbital configuration. |  AU, arcsec |
 | `positionangle` | `binary` | Position angle | degree |
 | `eccentricity` 	| `binary`, `planet` | Eccentricity  | |
-| `periastron` 	| `binary`, `planet` | Longitude of periastron | degree  |
+| `periastron` 	| `binary`, `planet` | Longitude of periastron, can take an optional `component` attribute to specify whether it refers to the primary (default) or secondary orbit (values 1 or 2 respectively). | degree  |
 | `longitude` 	| `binary`, `planet` | Mean longitude at a given Epoch (same for all planets in one system) | degree  |
 | `meananomaly`	| `binary`, `planet` | Mean anomaly at a given Epoch (same for all planets in one system) | degree  |
 | `ascendingnode` 	| `binary`, `planet` | Longitude of the ascending node | degree  |

--- a/cleanup.py
+++ b/cleanup.py
@@ -94,7 +94,8 @@ validattributes = [
     "unit",
     "upperlimit",
     "lowerlimit",
-    "type"]
+    "type",
+    "component"]
 validlists = [
     "Confirmed planets",
     "Planets in binary systems, S-type",

--- a/oec.xsd
+++ b/oec.xsd
@@ -33,7 +33,7 @@
 				<xs:element name="list" type="listtype" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="semimajoraxis" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="eccentricity" type="number" minOccurs="0" maxOccurs="1"/>
-				<xs:element name="periastron" type="number" minOccurs="0" maxOccurs="1"/>
+				<xs:element name="periastron" type="number-with-component" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="longitude" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="ascendingnode" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="inclination" type="number" minOccurs="0" maxOccurs="1"/>
@@ -100,7 +100,7 @@
 				<xs:element ref="planet"/>
 				<xs:element name="semimajoraxis" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="eccentricity" type="number"/>
-				<xs:element name="periastron" type="number"/>
+				<xs:element name="periastron" type="number-with-component"/>
 				<xs:element name="longitude" type="number"/>
 				<xs:element name="meananomaly" type="number"/>
 				<xs:element name="ascendingnode" type="number"/>
@@ -140,6 +140,21 @@
 				<xs:attribute name="lowerlimit" type="xs:double" use="optional"/>
 				<xs:attribute name="upperlimit" type="xs:double" use="optional"/>
 				<xs:attribute name="unit" type="xs:string" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<!-- Periastron -->
+	<xs:complexType name="number-with-component">
+		<xs:simpleContent>
+			<xs:extension base="periastron">
+				<xs:attribute name="component" use="optional">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>


### PR DESCRIPTION
So far I don't validate the value here in the cleanup script but I do specify the enumeration in the xsd. Not sure if we want to check the values also in cleanup.py?

Closes #306