### PR TITLE
Update K2-3

### DIFF
--- a/systems/EPIC 201367065.xml
+++ b/systems/EPIC 201367065.xml
@@ -7,14 +7,14 @@
 		<name>EPIC 201367065</name>
 		<name>K2-3</name>
 		<name>2MASS 11292037-0127173</name>
-		<mass errorminus="0.04" errorplus="0.04">0.56</mass>
-		<radius errorminus="0.04" errorplus="0.03">0.54</radius>
-		<temperature errorminus="43" errorplus="34">3943</temperature>
+		<mass errorminus="0.086" errorplus="0.086">0.612</mass>
+		<radius errorminus="0.041" errorplus="0.041">0.553</radius>
+		<temperature errorminus="190" errorplus="190">3900</temperature>
 		<magJ errorminus="0.03" errorplus="0.03">9.42</magJ>
 		<magH errorminus="0.04" errorplus="0.04">8.8</magH>
 		<magK errorminus="0.02" errorplus="0.02">8.56</magK>
 		<age lowerlimit="1" />
-		<metallicity errorminus="0.15" errorplus="0.16">-0.16</metallicity>
+		<metallicity errorminus="0.13" errorplus="0.13">-0.32</metallicity>
 		<spectraltype>M0.2V</spectraltype>
 		<planet>
 			<name>EPIC 201367065 b</name>
@@ -22,16 +22,19 @@
 			<name>K2-3 b</name>
 			<name>2MASS 11292037-0127173 b</name>
 			<list>Confirmed planets</list>
-			<radius errorminus="0.020" errorplus="0.020">0.195</radius>
-			<period errorminus="0.00032" errorplus="0.00032">10.05429</period>
-			<transittime errorminus="0.0019" errorplus="0.0019" unit="BJD">2456813.4184</transittime>
-			<semimajoraxis errorminus="0.002" errorplus="0.002">0.0749</semimajoraxis>
-			<inclination errorminus="0.6" errorplus="0.46">89.28</inclination>
-			<temperature errorminus="17" errorplus="17">507</temperature>
-			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission, Campaign 1.</description>
+			<radius errorminus="0.0083" errorplus="0.0161">0.1854</radius>
+			<period errorminus="0.00022" errorplus="0.00022">10.05429</period>
+			<transittime errorminus="0.00082" errorplus="0.00082" unit="BJD">2456813.41817</transittime>
+			<semimajoraxis errorminus="0.0039" errorplus="0.0039">0.0775</semimajoraxis>
+			<inclination errorminus="0.40" errorplus="0.24">89.59</inclination>
+			<eccentricity upperlimit="0.29" />
+			<periastron errorminus="70" errorplus="70">180</periastron>
+			<ascendingnode>180</ascendingnode>
+			<mass errorminus="0.0066" errorplus="0.0066">0.0264</mass>
+			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission, Campaign 1. Its mass has been determined through radial velocity measurements taken with HARPS, indicating it is rocky with up to 50% of the mass in a water envelope.</description>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
-			<lastupdate>15/03/26</lastupdate>
+			<lastupdate>15/09/12</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 		<planet>
@@ -40,16 +43,18 @@
 			<name>K2-3 c</name>
 			<name>2MASS 11292037-0127173 c</name>
 			<list>Confirmed planets</list>
-			<radius errorminus="0.014" errorplus="0.014">0.146</radius>
-			<period errorminus="0.00149" errorplus="0.00149">24.64682</period>
-			<transittime errorminus="0.0031" errorplus="0.0031" unit="BJD">2456812.2766</transittime>
-			<semimajoraxis errorminus="0.0036" errorplus="0.0036">0.1361</semimajoraxis>
-			<inclination errorminus="0.44" errorplus="0.29">89.55</inclination>
-			<temperature errorminus="13" errorplus="13">376</temperature>
-			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission, Campaign 1.</description>
+			<radius errorminus="0.0058" errorplus="0.0143">0.1467</radius>
+			<period errorminus="0.0033" errorplus="0.0033">24.6491</period>
+			<transittime errorminus="0.0018" errorplus="0.0018" unit="BJD">2456812.2784</transittime>
+			<semimajoraxis errorminus="0.0036" errorplus="0.0036">0.1405</semimajoraxis>
+			<inclination errorminus="0.20" errorplus="0.20">89.70</inclination>
+			<eccentricity upperlimit="0.20" />
+			<periastron errorminus="110" errorplus="110">89</periastron>
+			<ascendingnode errorminus="1.8">180.0</ascendingnode>
+			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission, Campaign 1. The radial velocity signature of this planet is masked by variations due to stellar activity, preventing an accurate mass determination.</description>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
-			<lastupdate>15/03/26</lastupdate>
+			<lastupdate>15/09/12</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 		<planet>
@@ -57,14 +62,18 @@
 			<name>K2-3 d</name>
 			<name>2MASS 11292037-0127173 d</name>
 			<list>Confirmed planets</list>
-			<radius errorminus="0.018226" errorplus="0.019137">0.138518</radius>
-			<period errorminus="0.00055" errorplus="0.0063">44.5631</period>
-			<semimajoraxis errorminus="0.0108" errorplus="0.0098">0.2076</semimajoraxis>
-			<inclination errorminus="0.26" errorplus="0.21">89.68</inclination>
-			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission. The planetary system consists of three transiting Super-Earths. The low-mass star is bright and nearby, which makes this system an excellent laboratory to determine the planets' masses via Doppler spectroscopy and to constrain their atmospheric compositions via transit spectroscopy.</description>
+			<radius errorminus="0.0098" errorplus="0.0098">0.1365</radius>
+			<period errorminus="0.00059" errorplus="0.0059">44.5705</period>
+			<semimajoraxis errorminus="0.010" errorplus="0.010">0.2086</semimajoraxis>
+			<inclination errorminus="0.15" errorplus="0.15">89.79</inclination>
+			<eccentricity upperlimit="0.19" />
+			<periastron errorminus="66" errorplus="66">351</periastron>
+			<ascendingnode errorminus="1.8">180.0</ascendingnode>
+			<transittime errorminus="0.0027" errorplus="0.0027" unit="BJD">2456826.2272</transittime>
+			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission. The planetary system consists of three transiting Super-Earths. The low-mass star is bright and nearby, which makes this system an excellent laboratory to determine the planets' masses via Doppler spectroscopy and to constrain their atmospheric compositions via transit spectroscopy. The radial velocity signature of this planet is masked by variations due to stellar activity, preventing an accurate mass determination.</description>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
-			<lastupdate>15/01/17</lastupdate>
+			<lastupdate>15/09/12</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 	</star>


### PR DESCRIPTION
Almenara et al. (2015) http://arxiv.org/abs/1509.02917

Masses for K2-3 c and d are omitted due to issues with stellar activity.