### PR TITLE
Updated WASP-47

### DIFF
--- a/systems/WASP-47.xml
+++ b/systems/WASP-47.xml
@@ -24,9 +24,10 @@
 			<eccentricity>0.0</eccentricity>
 			<inclination errorminus="0.23" errorplus="0.23">89.41</inclination>
 			<transittime errorminus="0.000061" errorplus="0.000061" unit="BJD">2457007.932132</transittime>
+			<spinorbitalignment errorminus="24" errorplus="24">0</spinorbitalignment>
 			<description>This hot Jupiter planet has been announced at the Extreme Solar Systems II conference in Jackson Hole by the WASP team. The K2 mission discovers two additional transiting planets in 2015.</description>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>15/08/10</lastupdate>
+			<lastupdate>15/09/20</lastupdate>
 			<discoveryyear>2011</discoveryyear>
 			<temperature>1119.7</temperature>
 			<istransiting>1</istransiting>


### PR DESCRIPTION
Spin-orbit alignment for WASP-47b
Sanchis-Ojeda et al. (2015) http://arxiv.org/abs/1509.05337

Closes #696