### PR TITLE
Four radial velocity planets (BOAO)

### DIFF
--- a/systems/8 Ursae Minoris.xml
+++ b/systems/8 Ursae Minoris.xml
@@ -32,7 +32,7 @@
 			<name>WDS J14568+7454A b</name>
 			<name>2MASS J14564834+7454032 b</name>
 			<list>Confirmed planets</list>
-			<mass type="msini" errorminus="0.2" errorplus="0.2">1.5</mass>
+			<mass errorminus="0.2" errorplus="0.2" type="msini">1.5</mass>
 			<period errorminus="4.5" errorplus="4.5">93.4</period>
 			<periastrontime errorminus="22.8" errorplus="22.8">2454108.5</periastrontime>
 			<semimajoraxis errorminus="0.03" errorplus="0.03">0.49</semimajoraxis>

--- a/systems/8 Ursae Minoris.xml
+++ b/systems/8 Ursae Minoris.xml
@@ -1,0 +1,46 @@
+<system>
+	<name>8 Ursae Minoris</name>
+	<rightascension>14 56 48.352</rightascension>
+	<declination>+74 54 03.34</declination>
+	<distance errorminus="11.0" errorplus="11.0">159.1</distance>
+	<star>
+		<name>8 Ursae Minoris</name>
+		<name>HD 133086</name>
+		<name>HIP 73136</name>
+		<name>TYC 4417-267-1</name>
+		<name>BD+75 547</name>
+		<name>PPM 8785</name>
+		<name>WDS J14568+7454A</name>
+		<name>2MASS J14564834+7454032</name>
+		<magB>7.817</magB>
+		<magV>6.843</magV>
+		<magJ errorminus="0.027" errorplus="0.027">5.069</magJ>
+		<magH errorminus="0.036" errorplus="0.036">4.749</magH>
+		<magK errorminus="0.020" errorplus="0.020">4.515</magK>
+		<mass errorminus="0.1" errorplus="0.1">1.8</mass>
+		<radius errorminus="0.4" errorplus="0.4">9.9</radius>
+		<temperature errorminus="7.5" errorplus="7.5">4847.4</temperature>
+		<metallicity errorminus="0.02" errorplus="0.02">-0.03</metallicity>
+		<spectraltype>K0</spectraltype>
+		<planet>
+			<name>8 Ursae Minoris b</name>
+			<name>HD 133086 b</name>
+			<name>HIP 73136 b</name>
+			<name>TYC 4417-267-1 b</name>
+			<name>BD+75 547 b</name>
+			<name>PPM 8785 b</name>
+			<name>WDS J14568+7454A b</name>
+			<name>2MASS J14564834+7454032 b</name>
+			<list>Confirmed planets</list>
+			<mass type="msini" errorminus="0.2" errorplus="0.2">1.5</mass>
+			<period errorminus="4.5" errorplus="4.5">93.4</period>
+			<periastrontime errorminus="22.8" errorplus="22.8">2454108.5</periastrontime>
+			<semimajoraxis errorminus="0.03" errorplus="0.03">0.49</semimajoraxis>
+			<eccentricity errorminus="0.18" errorplus="0.18">0.06</eccentricity>
+			<description>This planet was detected by the Bohyunsan Optical Astronomy Observatory (BOAO) which searches for exoplanets at northern circumpolar stars.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>15/09/30</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+	</star>
+</system>

--- a/systems/HD 11755.xml
+++ b/systems/HD 11755.xml
@@ -26,7 +26,7 @@
 			<name>BD+72 112 b</name>
 			<name>PPM 4856 b</name>
 			<list>Confirmed planets</list>
-			<mass type="msini" errorminus="1.0" errorplus="1.0">6.5</mass>
+			<mass errorminus="1.0" errorplus="1.0" type="msini">6.5</mass>
 			<period errorminus="3.2" errorplus="3.2">433.7</period>
 			<periastrontime errorminus="14.0" errorplus="14.0">2457018.2</periastrontime>
 			<semimajoraxis errorminus="0.04" errorplus="0.04">1.08</semimajoraxis>

--- a/systems/HD 11755.xml
+++ b/systems/HD 11755.xml
@@ -1,0 +1,40 @@
+<system>
+	<name>HD 11755</name>
+	<rightascension>01 58 50.087</rightascension>
+	<declination>+73 09 08.58</declination>
+	<distance errorminus="22.7" errorplus="22.7">231.5</distance>
+	<star>
+		<name>HD 11755</name>
+		<name>HIP 9242</name>
+		<name>TYC 4322-1310-1</name>
+		<name>BD+72 112</name>
+		<name>PPM 4856</name>
+		<magB errorminus="0.01" errorplus="0.01">8.11</magB>
+		<magV errorminus="0.01" errorplus="0.01">6.88</magV>
+		<magJ errorminus="0.186" errorplus="0.186">4.667</magJ>
+		<magH errorminus="0.228" errorplus="0.228">3.931</magH>
+		<magK errorminus="0.28" errorplus="0.28">3.76</magK>
+		<mass errorminus="0.1" errorplus="0.1">0.9</mass>
+		<radius errorminus="1" errorplus="1.0">27.3</radius>
+		<temperature errorminus="5" errorplus="5.0">4312.5</temperature>
+		<metallicity errorminus="0.02" errorplus="0.02">-0.74</metallicity>
+		<spectraltype>G5</spectraltype>
+		<planet>
+			<name>HD 11755 b</name>
+			<name>HIP 9242 b</name>
+			<name>TYC 4322-1310-1 b</name>
+			<name>BD+72 112 b</name>
+			<name>PPM 4856 b</name>
+			<list>Confirmed planets</list>
+			<mass type="msini" errorminus="1.0" errorplus="1.0">6.5</mass>
+			<period errorminus="3.2" errorplus="3.2">433.7</period>
+			<periastrontime errorminus="14.0" errorplus="14.0">2457018.2</periastrontime>
+			<semimajoraxis errorminus="0.04" errorplus="0.04">1.08</semimajoraxis>
+			<eccentricity errorminus="0.10" errorplus="0.10">0.19</eccentricity>
+			<description>This planet was detected by the Bohyunsan Optical Astronomy Observatory (BOAO) which searches for exoplanets at northern circumpolar stars.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>15/09/30</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+	</star>
+</system>

--- a/systems/HD 12648.xml
+++ b/systems/HD 12648.xml
@@ -26,7 +26,7 @@
 			<name>BD+85 41 b</name>
 			<name>PPM 401,2MASS J02185973+8544102 b</name>
 			<list>Confirmed planets</list>
-			<mass type="msini" errorminus="0.4" errorplus="0.4">2.9</mass>
+			<mass errorminus="0.4" errorplus="0.4" type="msini">2.9</mass>
 			<period errorminus="0.5" errorplus="0.5">133.6</period>
 			<periastrontime errorminus="57.6" errorplus="57.6">2452324.7</periastrontime>
 			<semimajoraxis errorminus="0.02" errorplus="0.02">0.54</semimajoraxis>

--- a/systems/HD 12648.xml
+++ b/systems/HD 12648.xml
@@ -1,0 +1,40 @@
+<system>
+	<name>HD 12648</name>
+	<rightascension>02 18 59.654</rightascension>
+	<declination>+85 44 10.22</declination>
+	<distance errorminus="9.0" errorplus="9.0">158.4</distance>
+	<star>
+		<name>HD 12648</name>
+		<name>HIP 10800</name>
+		<name>TYC 4620-542-1</name>
+		<name>BD+85 41</name>
+		<name>PPM 401,2MASS J02185973+8544102</name>
+		<magB errorminus="0.01" errorplus="0.01">7.90</magB>
+		<magV errorminus="0.01" errorplus="0.01">6.98</magV>
+		<magJ errorminus="0.023" errorplus="0.023">5.302</magJ>
+		<magH errorminus="0.046" errorplus="0.046">4.820</magH>
+		<magK errorminus="0.031" errorplus="0.031">4.743</magK>
+		<mass errorminus="0.1" errorplus="0.1">1.2</mass>
+		<radius errorminus="0.6" errorplus="0.6">9.2</radius>
+		<temperature errorminus="7.5" errorplus="7.5">4835.8</temperature>
+		<metallicity errorminus="0.02" errorplus="0.02">-0.57</metallicity>
+		<spectraltype>G5</spectraltype>
+		<planet>
+			<name>HD 12648 b</name>
+			<name>HIP 10800 b</name>
+			<name>TYC 4620-542-1 b</name>
+			<name>BD+85 41 b</name>
+			<name>PPM 401,2MASS J02185973+8544102 b</name>
+			<list>Confirmed planets</list>
+			<mass type="msini" errorminus="0.4" errorplus="0.4">2.9</mass>
+			<period errorminus="0.5" errorplus="0.5">133.6</period>
+			<periastrontime errorminus="57.6" errorplus="57.6">2452324.7</periastrontime>
+			<semimajoraxis errorminus="0.02" errorplus="0.02">0.54</semimajoraxis>
+			<eccentricity errorminus="0.16" errorplus="0.16">0.04</eccentricity>
+			<description>This planet was detected by the Bohyunsan Optical Astronomy Observatory (BOAO) which searches for exoplanets at northern circumpolar stars.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>15/09/30</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+	</star>
+</system>

--- a/systems/HD 132406.xml
+++ b/systems/HD 132406.xml
@@ -1,42 +1,32 @@
 <system>
-	<name>HD 24064</name>
-	<rightascension>03 56 36.297</rightascension>
-	<declination>+74 04 48.12</declination>
-	<distance errorminus="31.2" errorplus="31.2">264.4</distance>
+	<name>HD 132406</name>
+	<rightascension>14 56 55</rightascension>
+	<declination>+53 22 56</declination>
+	<distance>71</distance>
 	<star>
-		<name>HD 24064</name>
-		<name>HIP 18451</name>
-		<name>TYC 4339-2274-1</name>
-		<name>BD+73 204</name>
-		<name>PPM 5424</name>
-		<name>2MASS J03563629+7404482</name>
-		<magB errorminus="0.02" errorplus="0.02">8.23</magB>
-		<magV errorminus="0.01" errorplus="0.01">6.72</magV>
-		<magJ errorminus="0.294" errorplus="0.294">4.317</magJ>
-		<magH errorminus="0.266" errorplus="0.266">3.432</magH>
-		<magK errorminus="0.394" errorplus="0.394">3.130</magK>
-		<mass errorminus="0.1" errorplus="0.1">1.0</mass>
-		<radius errorminus="2.9" errorplus="2.9">38.0</radius>
-		<temperature errorminus="22.5" errorplus="22.5">4052.5</temperature>
-		<metallicity errorminus="0.06" errorplus="0.06">-0.49</metallicity>
-		<spectraltype>K0</spectraltype>
+		<mass>1.09</mass>
+		<magV>8.45</magV>
+		<magB errorminus="0.007" errorplus="0.007">9.100</magB>
+		<magR>8.1</magR>
+		<magI>7.8</magI>
+		<magJ errorminus="0.023" errorplus="0.023">7.250</magJ>
+		<magH errorminus="0.031" errorplus="0.031">6.985</magH>
+		<magK errorminus="0.017" errorplus="0.017">6.870</magK>
+		<metallicity>0.18</metallicity>
+		<spectraltype>G0V</spectraltype>
 		<planet>
-			<name>HD 24064 b</name>
-			<name>HIP 18451 b</name>
-			<name>TYC 4339-2274-1 b</name>
-			<name>BD+73 204 b</name>
-			<name>PPM 5424 b</name>
-			<name>2MASS J03563629+7404482 b</name>
+			<name>HD 132406 b</name>
 			<list>Confirmed planets</list>
-			<mass type="msini" errorminus="1.3" errorplus="1.3">9.4</mass>
-			<period errorminus="3.0" errorplus="3.0">536.6</period>
-			<periastrontime errorminus="11.8" errorplus="11.8">2455278.3</periastrontime>
-			<semimajoraxis errorminus="0.05" errorplus="0.05">1.29</semimajoraxis>
-			<eccentricity errorminus="0.08" errorplus="0.08">0.35</eccentricity>
-			<description>This planet was detected by the Bohyunsan Optical Astronomy Observatory (BOAO) which searches for exoplanets at northern circumpolar stars.</description>
+			<mass>5.61</mass>
+			<period>974</period>
+			<semimajoraxis>1.98</semimajoraxis>
+			<eccentricity>0.34</eccentricity>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/09/30</lastupdate>
-			<discoveryyear>2015</discoveryyear>
+			<lastupdate>07/10/31</lastupdate>
+			<discoveryyear>2007</discoveryyear>
+			<temperature>209.0</temperature>
 		</planet>
+		<name>HD 132406</name>
+		<temperature>5885.0</temperature>
 	</star>
 </system>

--- a/systems/HD 132406.xml
+++ b/systems/HD 132406.xml
@@ -1,32 +1,42 @@
 <system>
-	<name>HD 132406</name>
-	<rightascension>14 56 55</rightascension>
-	<declination>+53 22 56</declination>
-	<distance>71</distance>
+	<name>HD 24064</name>
+	<rightascension>03 56 36.297</rightascension>
+	<declination>+74 04 48.12</declination>
+	<distance errorminus="31.2" errorplus="31.2">264.4</distance>
 	<star>
-		<mass>1.09</mass>
-		<magV>8.45</magV>
-		<magB errorminus="0.007" errorplus="0.007">9.100</magB>
-		<magR>8.1</magR>
-		<magI>7.8</magI>
-		<magJ errorminus="0.023" errorplus="0.023">7.250</magJ>
-		<magH errorminus="0.031" errorplus="0.031">6.985</magH>
-		<magK errorminus="0.017" errorplus="0.017">6.870</magK>
-		<metallicity>0.18</metallicity>
-		<spectraltype>G0V</spectraltype>
+		<name>HD 24064</name>
+		<name>HIP 18451</name>
+		<name>TYC 4339-2274-1</name>
+		<name>BD+73 204</name>
+		<name>PPM 5424</name>
+		<name>2MASS J03563629+7404482</name>
+		<magB errorminus="0.02" errorplus="0.02">8.23</magB>
+		<magV errorminus="0.01" errorplus="0.01">6.72</magV>
+		<magJ errorminus="0.294" errorplus="0.294">4.317</magJ>
+		<magH errorminus="0.266" errorplus="0.266">3.432</magH>
+		<magK errorminus="0.394" errorplus="0.394">3.130</magK>
+		<mass errorminus="0.1" errorplus="0.1">1.0</mass>
+		<radius errorminus="2.9" errorplus="2.9">38.0</radius>
+		<temperature errorminus="22.5" errorplus="22.5">4052.5</temperature>
+		<metallicity errorminus="0.06" errorplus="0.06">-0.49</metallicity>
+		<spectraltype>K0</spectraltype>
 		<planet>
-			<name>HD 132406 b</name>
+			<name>HD 24064 b</name>
+			<name>HIP 18451 b</name>
+			<name>TYC 4339-2274-1 b</name>
+			<name>BD+73 204 b</name>
+			<name>PPM 5424 b</name>
+			<name>2MASS J03563629+7404482 b</name>
 			<list>Confirmed planets</list>
-			<mass>5.61</mass>
-			<period>974</period>
-			<semimajoraxis>1.98</semimajoraxis>
-			<eccentricity>0.34</eccentricity>
+			<mass type="msini" errorminus="1.3" errorplus="1.3">9.4</mass>
+			<period errorminus="3.0" errorplus="3.0">536.6</period>
+			<periastrontime errorminus="11.8" errorplus="11.8">2455278.3</periastrontime>
+			<semimajoraxis errorminus="0.05" errorplus="0.05">1.29</semimajoraxis>
+			<eccentricity errorminus="0.08" errorplus="0.08">0.35</eccentricity>
+			<description>This planet was detected by the Bohyunsan Optical Astronomy Observatory (BOAO) which searches for exoplanets at northern circumpolar stars.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>07/10/31</lastupdate>
-			<discoveryyear>2007</discoveryyear>
-			<temperature>209.0</temperature>
+			<lastupdate>15/09/30</lastupdate>
+			<discoveryyear>2015</discoveryyear>
 		</planet>
-		<name>HD 132406</name>
-		<temperature>5885.0</temperature>
 	</star>
 </system>

--- a/systems/HD 24064.xml
+++ b/systems/HD 24064.xml
@@ -1,0 +1,42 @@
+<system>
+	<name>HD 24064</name>
+	<rightascension>03 56 36.297</rightascension>
+	<declination>+74 04 48.12</declination>
+	<distance errorminus="31.2" errorplus="31.2">264.4</distance>
+	<star>
+		<name>HD 24064</name>
+		<name>HIP 18451</name>
+		<name>TYC 4339-2274-1</name>
+		<name>BD+73 204</name>
+		<name>PPM 5424</name>
+		<name>2MASS J03563629+7404482</name>
+		<magB errorminus="0.02" errorplus="0.02">8.23</magB>
+		<magV errorminus="0.01" errorplus="0.01">6.72</magV>
+		<magJ errorminus="0.294" errorplus="0.294">4.317</magJ>
+		<magH errorminus="0.266" errorplus="0.266">3.432</magH>
+		<magK errorminus="0.394" errorplus="0.394">3.130</magK>
+		<mass errorminus="0.1" errorplus="0.1">1.0</mass>
+		<radius errorminus="2.9" errorplus="2.9">38.0</radius>
+		<temperature errorminus="22.5" errorplus="22.5">4052.5</temperature>
+		<metallicity errorminus="0.06" errorplus="0.06">-0.49</metallicity>
+		<spectraltype>K0</spectraltype>
+		<planet>
+			<name>HD 24064 b</name>
+			<name>HIP 18451 b</name>
+			<name>TYC 4339-2274-1 b</name>
+			<name>BD+73 204 b</name>
+			<name>PPM 5424 b</name>
+			<name>2MASS J03563629+7404482 b</name>
+			<list>Confirmed planets</list>
+			<mass type="msini" errorminus="1.3" errorplus="1.3">9.4</mass>
+			<period errorminus="3.0" errorplus="3.0">536.6</period>
+			<periastrontime errorminus="11.8" errorplus="11.8">2455278.3</periastrontime>
+			<semimajoraxis errorminus="0.05" errorplus="0.05">1.29</semimajoraxis>
+			<eccentricity errorminus="0.08" errorplus="0.08">0.35</eccentricity>
+			<description>This planet was detected by the Bohyunsan Optical Astronomy Observatory (BOAO) which searches for exoplanets at northern circumpolar stars.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>15/09/30</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+	</star>
+</system>

--- a/systems/HD 24064.xml
+++ b/systems/HD 24064.xml
@@ -28,7 +28,7 @@
 			<name>PPM 5424 b</name>
 			<name>2MASS J03563629+7404482 b</name>
 			<list>Confirmed planets</list>
-			<mass type="msini" errorminus="1.3" errorplus="1.3">9.4</mass>
+			<mass errorminus="1.3" errorplus="1.3" type="msini">9.4</mass>
 			<period errorminus="3.0" errorplus="3.0">536.6</period>
 			<periastrontime errorminus="11.8" errorplus="11.8">2455278.3</periastrontime>
 			<semimajoraxis errorminus="0.05" errorplus="0.05">1.29</semimajoraxis>


### PR DESCRIPTION
Four radial velocity planets (BOAO)
HD 11755,HD 12648,HD 24064,8 Ursae Minoris
source
http://arxiv.org/abs/1509.09012, additional alt names and magnitudes from SIMBAD
closes #721