### PR TITLE
Update Kepler-436.xml

### DIFF
--- a/systems/Kepler-436.xml
+++ b/systems/Kepler-436.xml
@@ -38,8 +38,8 @@
 			<name>KOI-2529.01</name>
 			<list>Controversial</list>
 			<radius errorminus="0.015" errorplus="0.012">0.152</radius>
-			<period errorminus="0.000131" errorplus="0.000131">16.796995</period>
-			<transittime errorminus="0.00425" errorplus="0.00425">2454967.04279</transittime>
+			<period errorminus="0.0008561" errorplus="0.0008561">16.79713874</period>  
+			<transittime errorminus="0.00404" errorplus="0.00404">2454967.04221</transittime>  
 			<description>KOI-2529.01 is an unconfirmed exoplanet candidate that was identified in the Q1-Q6 Kepler KOI list.</description>
 			<inclination>89.95</inclination>
 			<discoverymethod>transit</discoverymethod>


### PR DESCRIPTION
set to original values but now with correct transittime (julian date)
source  NASA KOI Overview for KOI-2529.01
http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=K02529.01&type=KEPLER_CANDIDATE

closes #709