### PR TITLE
Update cleanup script to output files in text mode

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -353,7 +353,8 @@ for filename in glob.glob("systems*/*.xml"):
     indent(root)
 
     # Write XML to file.
-    ET.ElementTree(root).write(filename, encoding="UTF-8", xml_declaration=False)
+    with open(filename, 'w') as outfile:
+        ET.ElementTree(root).write(outfile, encoding="UTF-8", xml_declaration=False)
 
     # Check for new md5
     f = open(filename, 'rt')


### PR DESCRIPTION
Uses system-specific line-endings in the XML files, making it easier to work with Git's default line-ending conversion rules on Windows.