### PR TITLE
Fix for ascendingnode element

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -112,7 +112,7 @@ numerictags = ["mass", "radius", "ascnedingnode", "discoveryyear", "semimajoraxi
     "magV", "magJ", "magH", "magR", "magB", "magK", "magI", "magU", "distance", "longitude", "age",
     "metallicity", "inclination", "periastron", "eccentricity", "temperature", "transittime",
     "spinorbitalignment", "separation", "positionangle", "periastrontime", "meananomaly",
-    "maximumrvtime"]
+    "maximumrvtime", "ascendingnode"]
 numericattributes = ["error", "errorplus", "errorminus", "upperlimit", "lowerlimit"]
 nonzeroattributes = ["error", "errorplus", "errorminus"]
 

--- a/systems/51 Eri.xml
+++ b/systems/51 Eri.xml
@@ -67,7 +67,7 @@
 			<period errorminus="237" errorplus="237">10650</period>
 			<periastron errorminus="3" errorplus="3">-69</periastron>
 			<periastrontime errorminus="66" errorplus="66">2451592</periastrontime>
-			<ascendingnode errorminus="0.2">18.8</ascendingnode>
+			<ascendingnode errorminus="0.2" errorplus="0.2">18.8</ascendingnode>
 			<star>
 				<name>GJ 3305 A</name>
 				<name>WDS J04376-0228 Ca</name>

--- a/systems/Alpha Centauri.xml
+++ b/systems/Alpha Centauri.xml
@@ -25,7 +25,7 @@
 		<inclination errorminus="0.041" errorplus="0.041">79.20</inclination>
 		<period errorminus="4.0" errorplus="4.0">29187.1</period>
 		<periastron errorminus="0.076" errorplus="0.076">231.65</periastron>
-		<ascendingnode errorminus="0.084">204.85</ascendingnode>
+		<ascendingnode errorminus="0.084" errorplus="0.084">204.85</ascendingnode>
 		<periastrontime errorminus="4.4" errorplus="4.4">2406130.3</periastrontime>
 		<star>
 			<name>Alpha Centauri A</name>

--- a/systems/EPIC 201367065.xml
+++ b/systems/EPIC 201367065.xml
@@ -52,7 +52,7 @@
 			<inclination errorminus="0.86" errorplus="0.62">89.12</inclination>
 			<eccentricity upperlimit="0.20" />
 			<periastron errorminus="110" errorplus="110">89</periastron>
-			<ascendingnode errorminus="1.8">180</ascendingnode>
+			<ascendingnode errorminus="1.8" errorplus="1.8">180</ascendingnode>
 			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission, Campaign 1. The radial velocity signature of this planet is masked by variations due to stellar activity, preventing an accurate mass determination.</description>
 			<discoverymethod>transit</discoverymethod>
 			<istransiting>1</istransiting>
@@ -70,7 +70,7 @@
 			<inclination errorminus="0.64" errorplus="0.43">89.38</inclination>
 			<eccentricity upperlimit="0.19" />
 			<periastron errorminus="66" errorplus="66">351</periastron>
-			<ascendingnode errorminus="1.8">180</ascendingnode>
+			<ascendingnode errorminus="1.8" errorplus="1.8">180</ascendingnode>
 			<transittime errorminus="0.0034" errorplus="0.0034" unit="BJD">2456826.2288</transittime>
 			<description>This planet was discovered by the Kepler spacecraft during its extended K2 mission. The planetary system consists of three transiting Super-Earths. The low-mass star is bright and nearby, which makes this system an excellent laboratory to determine the planets' masses via Doppler spectroscopy and to constrain their atmospheric compositions via transit spectroscopy. The radial velocity signature of this planet is masked by variations due to stellar activity, preventing an accurate mass determination.</description>
 			<discoverymethod>transit</discoverymethod>

--- a/systems/Gliese 15.xml
+++ b/systems/Gliese 15.xml
@@ -12,7 +12,7 @@
 		<period errorminus="94600" errorplus="94600">457700</period>
 		<semimajoraxis errorminus="12.7" errorplus="12.7">95.9</semimajoraxis>
 		<inclination errorminus="11" errorplus="11">46</inclination>
-		<ascendingnode errorminus="25">243</ascendingnode>
+		<ascendingnode errorminus="25" errorplus="25">243</ascendingnode>
 		<periastrontime errorminus="29600" errorplus="29600">2571000</periastrontime>
 		<eccentricity errorminus="0.19" errorplus="0.19">0.59</eccentricity>
 		<periastron errorminus="32" errorplus="32">331</periastron>

--- a/systems/HR 8799.xml
+++ b/systems/HR 8799.xml
@@ -34,7 +34,7 @@
 			<semimajoraxis errorminus="1.85" errorplus="1.85">67.96</semimajoraxis>
 			<eccentricity>0</eccentricity>
 			<inclination errorminus="4.95" errorplus="4.95">30.27</inclination>
-			<ascendingnode errorminus="4.40">60.89</ascendingnode>
+			<ascendingnode errorminus="4.40" errorplus="4.40">60.89</ascendingnode>
 			<temperature>1100</temperature>
 			<spectraltype>L/T</spectraltype>
 			<metallicity>0.5</metallicity>
@@ -55,7 +55,7 @@
 			<semimajoraxis errorminus="1.16" errorplus="1.16">42.81</semimajoraxis>
 			<eccentricity>0</eccentricity>
 			<inclination errorminus="0.35" errorplus="0.35">29.43</inclination>
-			<ascendingnode errorminus="2.67">65.68</ascendingnode>
+			<ascendingnode errorminus="2.67" errorplus="2.67">65.68</ascendingnode>
 			<temperature>1200</temperature>
 			<spectraltype>L/T</spectraltype>
 			<metallicity>0.5</metallicity>
@@ -76,7 +76,7 @@
 			<semimajoraxis errorminus="0.73" errorplus="0.73">26.97</semimajoraxis>
 			<eccentricity>0</eccentricity>
 			<inclination errorminus="2.84" errorplus="2.84">38.63</inclination>
-			<ascendingnode errorminus="3.78">56.09</ascendingnode>
+			<ascendingnode errorminus="3.78" errorplus="3.78">56.09</ascendingnode>
 			<temperature>1200</temperature>
 			<spectraltype>L7</spectraltype>
 			<metallicity>0.5</metallicity>
@@ -97,7 +97,7 @@
 			<semimajoraxis errorminus="0.46" errorplus="0.46">16.99</semimajoraxis>
 			<eccentricity>0</eccentricity>
 			<inclination errorminus="1.43" errorplus="1.43">30.95</inclination>
-			<ascendingnode errorminus="7.11">145.73</ascendingnode>
+			<ascendingnode errorminus="7.11" errorplus="7.11">145.73</ascendingnode>
 			<temperature>1200</temperature>
 			<spectraltype>L7</spectraltype>
 			<metallicity>0.5</metallicity>

--- a/systems/KOI-1474.xml
+++ b/systems/KOI-1474.xml
@@ -46,7 +46,7 @@
 			<eccentricity errorminus="0.002" errorplus="0.002">0.184</eccentricity>
 			<periastron errorminus="1.0" errorplus="1.2">275.3</periastron>
 			<meananomaly errorminus="0.3" errorplus="0.3">345.0</meananomaly>
-			<ascendingnode errorminus="12">4</ascendingnode>
+			<ascendingnode errorminus="12" errorplus="12">4</ascendingnode>
 			<inclination errorminus="2" errorplus="3">88</inclination>
 			<description>The planet KOI-1474 c was initially identified by transit timing variations. The timing variations allowed for the planet's properties to be effectively constrained, revealing that the two giant planets in this system have well-aligned orbits.</description>
 			<discoverymethod>timing</discoverymethod>

--- a/systems/Kepler-444.xml
+++ b/systems/Kepler-444.xml
@@ -15,7 +15,7 @@
 		<semimajoraxis errorminus="0.9" errorplus="0.7">36.7</semimajoraxis>
 		<eccentricity errorminus="0.023" errorplus="0.023">0.864</eccentricity>
 		<inclination errorminus="3.6" errorplus="3.4">90.4</inclination>
-		<ascendingnode errorminus="0.9">73.1</ascendingnode>
+		<ascendingnode errorminus="0.9" errorplus="0.9">73.1</ascendingnode>
 		<periastron errorminus="2.6" errorplus="3.2">342.8</periastron>
 		<period errorminus="3300" errorplus="2900">1584</period>
 		<periastrontime errorminus="900" errorplus="900">2488500</periastrontime>

--- a/systems/gamma Cephei.xml
+++ b/systems/gamma Cephei.xml
@@ -35,7 +35,7 @@
 		<period errorminus="511" errorplus="511">24654</period>
 		<periastron errorminus="0.40" errorplus="0.40">161.01</periastron>
 		<periastrontime errorminus="11.3" errorplus="11.3">2448478.3</periastrontime>
-		<ascendingnode errorminus="0.98">18.04</ascendingnode>
+		<ascendingnode errorminus="0.98" errorplus="0.98">18.04</ascendingnode>
 		<star>
 			<name>gamma Cephei A</name>
 			<name>Gamma Cephei A</name>

--- a/systems/tau Boo.xml
+++ b/systems/tau Boo.xml
@@ -9,7 +9,7 @@
 		<name>HIP 67275</name>
 		<semimajoraxis errorminus="110" errorplus="110">120</semimajoraxis>
 		<eccentricity errorminus="0.074" errorplus="0.074">0.836</eccentricity>
-		<ascendingnode errorminus="50.3">171.9</ascendingnode>
+		<ascendingnode errorminus="50.3" errorplus="50.3">171.9</ascendingnode>
 		<inclination errorminus="39.7" errorplus="39.7">37.0</inclination>
 		<period errorminus="482500" errorplus="482500">352100</period>
 		<periastrontime errorminus="1800" errorplus="1800">2462500</periastrontime>


### PR DESCRIPTION
The "ascendingnode" tag was not in the list of numeric tags, so the corresponding error tag was not filled in if only one was provided.

This pull request fixes this omission and updates the relevant data files.