### PR TITLE
Add the "new" subelement for the planet element

### DIFF
--- a/oec.xsd
+++ b/oec.xsd
@@ -50,6 +50,7 @@
 				<xs:element name="age" type="number" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="discoverymethod" type="discoverymethodtype" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="istransiting" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+				<xs:element name="new" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="discoveryyear" type="year" minOccurs="0" maxOccurs="1"/>
 				<xs:element name="lastupdate" type="lastupdatedef" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
Related to `/systems/Kepler-1000.xml`  where "new" is used, it must be defined for XSD validation.

https://github.com/OpenExoplanetCatalogue/open_exoplanet_catalogue/blob/master/systems/Kepler-1000.xml#L18