### PR TITLE
Fix Kepler-1013 b right ascension

### DIFF
--- a/systems/Kepler-1013.xml
+++ b/systems/Kepler-1013.xml
@@ -1,6 +1,6 @@
 <system>
 	<name>Kepler-1013</name>
-	<rightascension>19 20 60</rightascension>
+	<rightascension>19 20 59.5</rightascension>
 	<declination>+44 26 07</declination>
 	<star>
 		<name>Kepler-1013</name>


### PR DESCRIPTION
According to the NASA Exoplanet Archive, right ascension for Kepler-1013 b is 19 20 59.54
Ref: http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-1013+b&type=CONFIRMED_PLANET