### PR TITLE
Fix rightascensiondef validation pattern

### DIFF
--- a/oec.xsd
+++ b/oec.xsd
@@ -170,7 +170,7 @@
 	<!-- Right Ascension Definition -->
 	<xs:simpleType name="rightascensiondef">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-2]\d [0-5]\d [0-5]\d(\.\d+)?"/>
+			<xs:pattern value="[0-2]\d [0-5]\d ([0-5]\d(\.\d+)?|60)"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<!-- Declination Definition -->


### PR DESCRIPTION
Related to `/systems/Kepler-1099.xml`

The value '19 14 60' is not accepted by the pattern '[0-2]\d [0-5]\d [0-5]\d(\.\d+)?'.

https://github.com/OpenExoplanetCatalogue/open_exoplanet_catalogue/blob/master/systems/Kepler-1099.xml#L3