### PR TITLE
Fix declinationdef validation pattern

### DIFF
--- a/oec.xsd
+++ b/oec.xsd
@@ -176,7 +176,7 @@
 	<!-- Declination Definition -->
 	<xs:simpleType name="declinationdef">
 		<xs:restriction base="xs:string">
-			<xs:pattern value="(\+|\-)(\d{2} [0-5]\d [0-5]\d)(\.\d+)?"/>
+			<xs:pattern value="(\+|\-)\d{2} [0-5]\d ([0-5]\d(\.\d+)?|60)"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<!-- DateTime -->


### PR DESCRIPTION
Related to `/systems/Kepler-1172.xml`

The value '+37 45 60' is not accepted by the pattern '(\+|\-)(\d{2} [0-5]\d [0-5]\d)(\.\d+)?'.

https://github.com/OpenExoplanetCatalogue/open_exoplanet_catalogue/blob/master/systems/Kepler-1172.xml#L4