### PR TITLE
Fix right ascension

### DIFF
--- a/systems/Kepler-1099.xml
+++ b/systems/Kepler-1099.xml
@@ -1,6 +1,6 @@
 <system>
 	<name>Kepler-1099</name>
-	<rightascension>19 14 60</rightascension>
+	<rightascension>19 14 59.9</rightascension>
 	<declination>+48 16 38</declination>
 	<star>
 		<name>Kepler-1099</name>


### PR DESCRIPTION
The value '19 14 60' is not accepted by the pattern '[0-2]\d [0-5]\d [0-5]\d(.\d+)?'.

https://github.com/OpenExoplanetCatalogue/open_exoplanet_catalogue/blob/master/systems/Kepler-1099.xml#L3

ref. http://exoplanetarchive.ipac.caltech.edu/cgi-bin/DisplayOverview/nph-DisplayOverview?objname=Kepler-1099+b&type=CONFIRMED_PLANET

Do you think we could make pattern more precise, with 2 digits ? Current one does not accept 59.99 which seems to be a great precision.