### PR TITLE
Update HD 106906

### DIFF
--- a/systems/HD 106906.xml
+++ b/systems/HD 106906.xml
@@ -3,31 +3,45 @@
 	<rightascension>12 17 53.19228</rightascension>
 	<declination>-55 58 31.8890</declination>
 	<distance errorminus="6" errorplus="6">92</distance>
-	<star>
+	<binary>
 		<name>HD 106906</name>
-		<mass errorminus="0.1" errorplus="0.1">1.5</mass>
-		<temperature errorminus="165" errorplus="165">6516</temperature>
-		<magV>7.81</magV>
-		<magB>8.21</magB>
-		<magH errorminus="0.038" errorplus="0.038">6.759</magH>
-		<magK errorminus="0.026" errorplus="0.026">6.683</magK>
-		<age errorminus="0.002" errorplus="0.002">0.013</age>
-		<spectraltype>F5V</spectraltype>
-		<magJ errorminus="0.03" errorplus="0.03">6.95</magJ>
+		<name>HIP 59960</name>
+		<name>TYC 8637-2434-1</name>
+		<name>CD-55 4537</name>
+		<name>CPD-55 4978</name>
+		<name>2MASS J12175319-5558319</name>
+		<name>SAO 239819</name>
+		<separation lowerlimit="0.36" unit="AU" upperlimit="0.58" />
+		<star>
+			<name>HD 106906 A</name>
+			<spectraltype>F5V</spectraltype>
+			<mass>1.34</mass>
+			<magV>8.11</magV>
+			<age errorminus="0.002" errorplus="0.002">0.013</age>
+		</star>
+		<star>
+			<name>HD 106906 B</name>
+			<spectraltype>F5V</spectraltype>
+			<mass>1.37</mass>
+			<magV>8.11</magV>
+			<age errorminus="0.002" errorplus="0.002">0.013</age>
+		</star>
 		<planet>
 			<name>HD 106906 b</name>
+			<name>HD 106906 (AB) b</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="2" errorplus="2">11</mass>
-			<spectraltype>L2.5</spectraltype>
-			<temperature errorminus="100" errorplus="100">1800</temperature>
+			<mass errorminus="0.7" errorplus="0.8">12.3</mass>
+			<spectraltype errorminus="1.0">L1.5</spectraltype>
+			<temperature errorminus="240" errorplus="240">1820</temperature>
 			<separation errorminus="0.03" errorplus="0.03" unit="arcsec">7.11</separation>
 			<separation unit="AU">650</separation>
 			<positionangle errorminus="0.2" errorplus="0.2">307.3</positionangle>
 			<magJ errorminus="0.3" errorplus="0.3">17.6</magJ>
-			<description>The star HD 106906 hosts a massive debris disk with an inner edge at 15-20 AU and an outer edge at 120 AU. New adaptive optics images from the Magellan telescope revealed a planetary mass companion far beyond the debris disk at 650 AU. Explaining the formation of such a wide companion is challenging.</description>
+			<description>The binary star HD 106906 hosts a massive debris disk with an inner edge at 15-20 AU and an outer edge at 120 AU. New adaptive optics images from the Magellan telescope revealed a planetary mass companion far beyond the debris disk at 650 AU. Explaining the formation of such a wide companion is challenging.</description>
 			<discoverymethod>imaging</discoverymethod>
-			<lastupdate>13/12/06</lastupdate>
+			<lastupdate>17/11/30</lastupdate>
 			<discoveryyear>2013</discoveryyear>
+			<list>Planets in binary systems, P-type</list>
 		</planet>
-	</star>
+	</binary>
 </system>


### PR DESCRIPTION
Binary star properties from Rodet et al. (2017), V-magnitudes given assuming that the two stars are of equal magnitude.
http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1703.01857

Updated parameters for HD 106906 (AB) b from Daemgen et al. (arXiv 2017)
https://arxiv.org/abs/1708.05747

Additional identifiers from SIMBAD

Resolves #738