### PR TITLE
Update HD 219134

### DIFF
--- a/systems/HD 219134.xml
+++ b/systems/HD 219134.xml
@@ -7,12 +7,13 @@
 		<name>HD 219134</name>
 		<name>BD+56 2966</name>
 		<name>GJ 892</name>
+		<name>Gliese 892</name>
 		<name>HIP 114622</name>
 		<name>HR 8832</name>
 		<name>2MASS J23131692+5710059</name>
 		<name>PPM 41599</name>
 		<name>TYC 4006-1866-1</name>
-		<mass errorminus="0.022" errorplus="0.037">0.794</mass>
+		<mass errorminus="0.03" errorplus="0.03">0.81</mass>
 		<radius errorminus="0.005" errorplus="0.005">0.778</radius>
 		<magU errorminus="0.010" errorplus="0.010">7.460</magU>
 		<magB errorminus="0.007" errorplus="0.007">6.560</magB>
@@ -30,130 +31,162 @@
 			<name>HD 219134 b</name>
 			<name>BD+56 2966 b</name>
 			<name>GJ 892 b</name>
+			<name>Gliese 892 b</name>
 			<name>HIP 114622 b</name>
 			<name>HR 8832 b</name>
 			<name>2MASS J23131692+5710059 b</name>
 			<name>PPM 41599 b</name>
 			<name>TYC 4006-1866-1 b</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="0.001" errorplus="0.001" type="msini">0.012</mass>
-			<period errorminus="0.0001" errorplus="0.0001">3.0931</period>
-			<meananomaly errorminus="20" errorplus="20">57</meananomaly>
-			<transittime errorminus="0.001" errorplus="0.001" unit="BJD">245126.7001</transittime>
-			<semimajoraxis errorminus="0.0000008" errorplus="0.0000008">0.0384740</semimajoraxis>
+			<mass errorminus="0.00060" errorplus="0.00060" type="msini">0.01491</mass>
+			<period errorminus="0.000010" errorplus="0.000010">3.092926</period>
+			<transittime errorminus="0.00087" errorplus="0.00087" unit="BJD">2457126.69913</transittime>
+			<semimajoraxis errorminus="0.00047" errorplus="0.00047">0.03876</semimajoraxis>
 			<eccentricity>0</eccentricity>
 			<periastron>0</periastron>
-			<radius errorminus="0.0077" errorplus="0.0077">0.1433</radius>
-			<inclination errorminus="0.080" errorplus="0.080">85.058</inclination>
+			<radius errorminus="0.00491" errorplus="0.00491">0.14292</radius>
+			<inclination errorminus="0.09" errorplus="0.09">85.05</inclination>
 			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively. Spitzer observations allowed the discoverers to detect the transit of the innermost planet in front of the star making HD 219134 b the nearest known transiting planet to date.</description>
 			<discoverymethod>RV</discoverymethod>
 			<istransiting>1</istransiting>
-			<lastupdate>15/10/20</lastupdate>
+			<lastupdate>17/12/14</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 		<planet>
 			<name>HD 219134 c</name>
 			<name>BD+56 2966 c</name>
 			<name>GJ 892 c</name>
+			<name>Gliese 892 c</name>
 			<name>HIP 114622 c</name>
 			<name>HR 8832 c</name>
 			<name>2MASS J23131692+5710059 c</name>
 			<name>PPM 41599 c</name>
 			<name>TYC 4006-1866-1 c</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="0.002" errorplus="0.002" type="msini">0.011</mass>
-			<period errorminus="0.0006" errorplus="0.0006">6.7635</period>
-			<meananomaly errorminus="27" errorplus="27">78</meananomaly>
-			<semimajoraxis errorminus="0.000004" errorplus="0.000004">0.064816</semimajoraxis>
-			<eccentricity>0</eccentricity>
-			<periastron>0</periastron>
-			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively</description>
+			<mass errorminus="0.00069" errorplus="0.00069">0.01372</mass>
+			<period errorminus="0.00033" errorplus="0.00033">6.76458</period>
+			<transittime errorminus="0.0008" errorplus="0.0008" unit="BJD">2457474.04591</transittime>
+			<semimajoraxis errorminus="0.00033" errorplus="0.00033">0.06530</semimajoraxis>
+			<eccentricity errorminus="0.039" errorplus="0.039">0.062</eccentricity>
+			<periastron errorminus="35" errorplus="24">70</periastron>
+			<inclination errorminus="0.10" errorplus="0.10">87.28</inclination>
+			<radius errorminus="0.00419" errorplus="0.00419">0.13480</radius>
+			<istransiting>1</istransiting>
+			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively. Transits of the second planet were detected in 2017.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/10/20</lastupdate>
-			<discoveryyear>2015</discoveryyear>
-		</planet>
-		<planet>
-			<name>HD 219134 d</name>
-			<name>BD+56 2966 d</name>
-			<name>GJ 892 d</name>
-			<name>HIP 114622 d</name>
-			<name>HR 8832 d</name>
-			<name>2MASS J23131692+5710059 d</name>
-			<name>PPM 41599 d</name>
-			<name>TYC 4006-1866-1 d</name>
-			<list>Confirmed planets</list>
-			<period errorminus="0.005" errorplus="0.005">22.805</period>
-			<mass errorminus="0.003" errorplus="0.003" type="msini">0.028</mass>
-			<meananomaly errorminus="20" errorplus="20">263</meananomaly>
-			<eccentricity>0</eccentricity>
-			<periastron>0</periastron>
-			<semimajoraxis errorminus="0.00002" errorplus="0.00002">0.14574</semimajoraxis>
-			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively.</description>
-			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/10/20</lastupdate>
-			<discoveryyear>2015</discoveryyear>
-		</planet>
-		<planet>
-			<name>HD 219134 e</name>
-			<name>BD+56 2966 e</name>
-			<name>GJ 892 e</name>
-			<name>HIP 114622 e</name>
-			<name>HR 8832 e</name>
-			<name>2MASS J23131692+5710059 e</name>
-			<name>PPM 41599 e</name>
-			<name>TYC 4006-1866-1 e</name>
-			<list>Confirmed planets</list>
-			<mass errorminus="0.004" errorplus="0.004" type="msini">0.067</mass>
-			<period errorminus="0.01" errorplus="0.01">46.71</period>
-			<semimajoraxis errorminus="0.00005" errorplus="0.00005">0.23508</semimajoraxis>
-			<eccentricity>0</eccentricity>
-			<periastron>0</periastron>
-			<meananomaly errorminus="11" errorplus="11">277</meananomaly>
-			<description>HD 219134 with its four low-mass planets is the first result of the Rocky Planet Search program with HARPS-N on the Telescopio Nazionale Galileo in La Palma. This planet was designated HD 219134 d in the HARPS-N announcement.</description>
-			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/10/20</lastupdate>
+			<lastupdate>17/12/14</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 		<planet>
 			<name>HD 219134 f</name>
 			<name>BD+56 2966 f</name>
 			<name>GJ 892 f</name>
+			<name>Gliese 892 f</name>
 			<name>HIP 114622 f</name>
 			<name>HR 8832 f</name>
 			<name>2MASS J23131692+5710059 f</name>
 			<name>PPM 41599 f</name>
 			<name>TYC 4006-1866-1 f</name>
 			<list>Confirmed planets</list>
-			<period errorminus="0.2" errorplus="0.2">94.2</period>
-			<mass errorminus="0.004" errorplus="0.004" type="msini">0.034</mass>
-			<meananomaly errorminus="35" errorplus="35">107</meananomaly>
-			<eccentricity>0</eccentricity>
-			<periastron>0</periastron>
-			<semimajoraxis errorminus="0.0004" errorplus="0.0004">0.3753</semimajoraxis>
+			<period errorminus="0.015" errorplus="0.015">22.717</period>
+			<mass errorminus="0.00126" errorplus="0.00126" type="msini">0.02297</mass>
+			<transittime errorminus="0.50" errorplus="0.50" unit="BJD">2457716.31</transittime>
+			<eccentricity errorminus="0.047" errorplus="0.047">0.148</eccentricity>
+			<periastron errorminus="17" errorplus="17">81</periastron>
+			<semimajoraxis errorminus="0.0018" errorplus="0.0018">0.1463</semimajoraxis>
+			<istransiting>0</istransiting>
 			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/10/20</lastupdate>
+			<lastupdate>17/12/14</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+		<planet>
+			<name>HD 219134 d</name>
+			<name>BD+56 2966 d</name>
+			<name>GJ 892 d</name>
+			<name>Gliese 892 d</name>
+			<name>HIP 114622 d</name>
+			<name>HR 8832 d</name>
+			<name>2MASS J23131692+5710059 d</name>
+			<name>PPM 41599 d</name>
+			<name>TYC 4006-1866-1 d</name>
+			<list>Confirmed planets</list>
+			<mass errorminus="0.002013" errorplus="0.002013" type="msini">0.050877</mass>
+			<period errorminus="0.028" errorplus="0.028">46.859</period>
+			<semimajoraxis errorminus="0.0030" errorplus="0.0030">0.2370</semimajoraxis>
+			<eccentricity errorminus="0.025" errorplus="0.025">0.138</eccentricity>
+			<periastron errorminus="10" errorplus="10">173</periastron>
+			<transittime errorminus="0.63" errorplus="0.63" unit="BJD">2457726.03</transittime>
+			<istransiting>0</istransiting>
+			<description>HD 219134 with its four low-mass planets is the first result of the Rocky Planet Search program with HARPS-N on the Telescopio Nazionale Galileo in La Palma. This planet was designated HD 219134 d in the HARPS-N announcement.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>17/12/14</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 		<planet>
 			<name>HD 219134 g</name>
 			<name>BD+56 2966 g</name>
 			<name>GJ 892 g</name>
+			<name>Gliese 892 g</name>
 			<name>HIP 114622 g</name>
 			<name>HR 8832 g</name>
 			<name>2MASS J23131692+5710059 g</name>
 			<name>PPM 41599 g</name>
 			<name>TYC 4006-1866-1 g</name>
 			<list>Confirmed planets</list>
-			<mass errorminus="0.02" errorplus="0.02" type="msini">0.34</mass>
-			<period errorminus="43" errorplus="43">2247</period>
-			<semimajoraxis errorminus="0.04" errorplus="0.04">3.11</semimajoraxis>
-			<eccentricity errorminus="0.04" errorplus="0.04">0.06</eccentricity>
-			<periastron errorminus="50" errorplus="50">215</periastron>
-			<meananomaly errorminus="56" errorplus="56">209</meananomaly>
+			<period errorminus="0.2" errorplus="0.2">94.2</period>
+			<mass errorminus="0.004" errorplus="0.004" type="msini">0.034</mass>
+			<periastrontime errorminus="9" errorplus="9">2449972</periastrontime>
+			<eccentricity>0</eccentricity>
+			<periastron>0</periastron>
+			<semimajoraxis errorminus="0.0004" errorplus="0.0004">0.3753</semimajoraxis>
+			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>17/12/14</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+		<planet>
+			<name>HD 219134 e</name>
+			<name>BD+56 2966 e</name>
+			<name>GJ 892 e</name>
+			<name>Gliese 892 e</name>
+			<name>HIP 114622 e</name>
+			<name>HR 8832 e</name>
+			<name>2MASS J23131692+5710059 e</name>
+			<name>PPM 41599 e</name>
+			<name>TYC 4006-1866-1 e</name>
+			<list>Retracted planet candidate</list>
+			<period errorminus="292" errorplus="4199">1842</period>
+			<maximumrvtime unit="BJD">2456330.84820</maximumrvtime>
+			<eccentricity errorminus="0.17" errorplus="0.17">0.34</eccentricity>
+			<periastron errorminus="36.83" errorplus="16.38">-14.58</periastron>
+			<mass errorminus="0.006" errorplus="0.189" type="msini">0.223</mass>
+			<semimajoraxis errorminus="0.15" errorplus="3.41">2.56</semimajoraxis>
+			<description>The planet candidate HD 219134 e was discovered by Motalebi et al. (2015). It was subsequently shown to be the same candidate as HD 219134 h from Vogt et al. (2015), and the latter name is now used for this planet.</description>
+			<discoverymethod>RV</discoverymethod>
+			<lastupdate>17/12/14</lastupdate>
+			<discoveryyear>2015</discoveryyear>
+		</planet>
+		<planet>
+			<name>HD 219134 h</name>
+			<name>BD+56 2966 h</name>
+			<name>GJ 892 h</name>
+			<name>Gliese 892 h</name>
+			<name>HIP 114622 h</name>
+			<name>HR 8832 h</name>
+			<name>2MASS J23131692+5710059 h</name>
+			<name>PPM 41599 h</name>
+			<name>TYC 4006-1866-1 h</name>
+			<list>Confirmed planets</list>
+			<mass errorminus="0.056" errorplus="0.056" type="msini">0.281</mass>
+			<period errorminus="51" errorplus="51">2198</period>
+			<semimajoraxis errorminus="0.048" errorplus="0.048">3.064</semimajoraxis>
+			<eccentricity errorminus="0.18" errorplus="0.18">0.37</eccentricity>
+			<periastron errorminus="19" errorplus="19">180</periastron>
+			<periastrontime unit="BJD">2448616.291</periastrontime>
 			<description>The planetary system around HD 219134 was discovered independently by teams using HARPS-N and APF, who announced four-planet and six-planet solutions respectively. In the HARPS-N solution, this planet was designated HD 219134 e and was assigned a shorter-period, more eccentric orbit.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>15/10/20</lastupdate>
+			<lastupdate>17/12/14</lastupdate>
 			<discoveryyear>2015</discoveryyear>
 		</planet>
 	</star>


### PR DESCRIPTION
Update planet designations to use current nomenclature.

Updated details for planets b, c, f and d from Gillon et al. (2017)
http://adsabs.harvard.edu/abs/2017NatAs...1E..56G

Updated details for planet h from Johnson et al. (2016)
http://adsabs.harvard.edu/abs/2016ApJ...821...74J

Use periastron time instead of mean anomaly for planet g from Vogt et al. (2015)
http://adsabs.harvard.edu/abs/2015ApJ...814...12V

Added details of retracted candidate e from Motalebi et al. (2015)
http://adsabs.harvard.edu/abs/2015A%26A...584A..72M

Resolves #869