### PR TITLE
Add unconfirmed planet around HD 26965 (40 Eri A)

### DIFF
--- a/systems/HD 26965.xml
+++ b/systems/HD 26965.xml
@@ -1,0 +1,145 @@
+<system>
+	<name>HD 26965</name>
+	<name>40 Eri</name>
+	<name>40 Eridani</name>
+	<name>omi02 Eri</name>
+	<name>Omicron-2 Eridani</name>
+	<name>ο2 Eri</name>
+	<name>ο2 Eridani</name>
+	<rightascension>04 15 16.31963</rightascension>
+	<declination>-07 39 10.3404</declination>
+	<distance errorminus="0.01" errorplus="0.01">4.98</distance>
+	<binary>
+		<name>40 Eri</name>
+		<name>40 Eridani</name>
+		<name>omi02 Eri</name>
+		<name>Omicron-2 Eridani</name>
+		<name>ο2 Eri</name>
+		<name>ο2 Eridani</name>
+		<name>Gliese 166</name>
+		<name>Gl 166</name>
+		<name>GJ 166</name>
+		<name>WDS J04153-0739</name>
+		<separation unit="arcsec">83.70</separation>
+		<separation unit="AU">417</separation>
+		<positionangle>102</positionangle>
+		<star>
+			<name>HD 26965</name>
+			<name>40 Eri A</name>
+			<name>40 Eridani A</name>
+			<name>omi02 Eri A</name>
+			<name>Omicron-2 Eridani A</name>
+			<name>ο2 Eri A</name>
+			<name>ο2 Eridani A</name>
+			<name>Keid</name>
+			<name>HIP 19849</name>
+			<name>TYC 5312-2325-1</name>
+			<name>Gliese 166 A</name>
+			<name>Gl 166 A</name>
+			<name>GJ 166 A</name>
+			<name>HR 1325</name>
+			<name>LHS 23</name>
+			<name>BD-07 780</name>
+			<name>2MASS J04151651-0739068</name>
+			<name>WDS J04153-0739 A</name>
+			<magU>5.69</magU>
+			<magB>5.25</magB>
+			<magV>4.43</magV>
+			<magR>3.74</magR>
+			<magI>3.29</magI>
+			<magJ>2.93</magJ>
+			<magH>2.48</magH>
+			<magK>2.41</magK>
+			<spectraltype>K0.5V</spectraltype>
+			<mass errorminus="0.03" errorplus="0.03">0.76</mass>
+			<age errorminus="4.84" errorplus="4.84">9.23</age>
+			<temperature errorminus="55" errorplus="55">5151</temperature>
+			<metallicity errorminus="0.12" errorplus="0.12">-0.29</metallicity>
+			<planet>
+				<name>HD 26965 b</name>
+				<list>Controversial</list>
+				<period errorminus="0.015" errorplus="0.015">42.364</period>
+				<eccentricity errorminus="0.046" errorplus="0.046">0.017</eccentricity>
+				<periastron errorminus="110.6" errorplus="110.6">17.8</periastron>
+				<meananomaly errorminus="110.0" errorplus="110.0">281.9</meananomaly>
+				<semimajoraxis errorminus="0.008" errorplus="0.008">0.215</semimajoraxis>
+				<mass errorminus="0.00249" errorplus="0.00249" type="msini">0.02174</mass>
+				<discoverymethod>RV</discoverymethod>
+				<discoveryyear>2018</discoveryyear>
+				<description>HD 26965 b is a candidate sub-Neptune planet orbiting the nearby star 40 Eridani A. It is not yet clear whether the radial velocity variations are due to an orbiting planet or stellar activity. The star system also contains a distant binary containing the white dwarf star 40 Eridani B and the flare star 40 Eridani C.</description>
+				<lastupdate>18/01/24</lastupdate>
+				<list>Planets in binary systems, S-type</list>
+			</planet>
+		</star>
+		<binary>
+			<name>40 Eri BC</name>
+			<name>40 Eridani BC</name>
+			<name>omi02 Eri BC</name>
+			<name>Omicron-2 Eridani BC</name>
+			<name>ο2 Eri BC</name>
+			<name>ο2 Eridani BC</name>
+			<name>Gliese 166 BC</name>
+			<name>Gl 166 BC</name>
+			<name>GJ 166 BC</name>
+			<name>WDS J04153-0739 BC</name>
+			<period errorminus="248" errorplus="248">84040</period>
+			<semimajoraxis errorminus="0.25" errorplus="0.25">34.54</semimajoraxis>
+			<inclination errorminus="0.29" errorplus="0.29">107.53</inclination>
+			<ascendingnode errorminus="0.12" errorplus="0.12">151.44</ascendingnode>
+			<periastrontime errorminus="402" errorplus="402">2395881</periastrontime>
+			<eccentricity errorminus="0.0027" errorplus="0.0027">0.4300</eccentricity>
+			<periastron errorminus="1.1" errorplus="1.1">318.2</periastron>
+			<star>
+				<name>40 Eri B</name>
+				<name>40 Eridani B</name>
+				<name>omi02 Eri B</name>
+				<name>Omicron-2 Eridani B</name>
+				<name>ο2 Eri B</name>
+				<name>ο2 Eridani B</name>
+				<name>WD 0413-077</name>
+				<name>Gliese 166 B</name>
+				<name>Gl 166 B</name>
+				<name>GJ 166 B</name>
+				<name>LHS 24</name>
+				<name>BD-07 781</name>
+				<name>WDS J04153-0739 B</name>
+				<magU>9.147</magU>
+				<magB>9.83</magB>
+				<magV>9.53</magV>
+				<magJ>9.849</magJ>
+				<magH>9.986</magH>
+				<magK>9.861</magK>
+				<spectraltype>DA2.9</spectraltype>
+				<temperature errorminus="110" errorplus="110">17200</temperature>
+				<radius errorminus="0.00020" errorplus="0.00020">0.01308</radius>
+				<mass errorminus="0.018" errorplus="0.018">0.575</mass>
+				<age>1.8</age>
+			</star>
+			<star>
+				<name>40 Eri C</name>
+				<name>40 Eridani C</name>
+				<name>omi02 Eri C</name>
+				<name>Omicron-2 Eridani C</name>
+				<name>ο2 Eri C</name>
+				<name>ο2 Eridani C</name>
+				<name>DY Eri</name>
+				<name>DY Eridani</name>
+				<name>Gliese 166 C</name>
+				<name>Gl 166 C</name>
+				<name>GJ 166 C</name>
+				<name>LHS 25</name>
+				<name>2MASS J04152173-0739173</name>
+				<name>WDS J04153-0739 C</name>
+				<magU>12.16</magU>
+				<magB>12.85</magB>
+				<magV>11.17</magV>
+				<magJ errorminus="0.020" errorplus="0.020">6.747</magJ>
+				<magH errorminus="0.04" errorplus="0.04">6.28</magH>
+				<magK errorminus="0.026" errorplus="0.026">5.962</magK>
+				<spectraltype>M4.5V</spectraltype>
+				<mass errorminus="0.0064" errorplus="0.0064">0.2041</mass>
+				<metallicity errorminus="0.13" errorplus="0.13">-0.21</metallicity>
+			</star>
+		</binary>
+	</binary>
+</system>


### PR DESCRIPTION
* Parameters for HD 26965 from [Díaz et al. (2018)](https://arxiv.org/abs/1801.03970)
* 40 Eri BC orbit and masses from [Mason et al. (2017)](http://adsabs.harvard.edu/abs/2017AJ....154..200M)
* 40 Eri B temperature, radius and age from [Bond et al. (2017)](https://ui.adsabs.harvard.edu/?#abs/2017ApJ...848...16B)
* 40 Eri C metallicity from [Newton et al. (2014)](http://cdsarc.u-strasbg.fr/viz-bin/Cat?J/AJ/147/20)
* 40 Eri AB separation and position angle from [WDS](http://cdsarc.u-strasbg.fr/viz-bin/Cat?B/wds)
* Coordinates, magnitudes, parallax and additional identifiers from SIMBAD