### PR TITLE
Fix incorrect designations leading to false-positive duplicates

### DIFF
--- a/systems/HD 233604.xml
+++ b/systems/HD 233604.xml
@@ -6,8 +6,8 @@
 		<name>HD 233604</name>
 		<name>TYC 3805-193-1</name>
 		<name>SAO 27142</name>
-		<name>BD+15 2940</name>
-		<name>2MASS J16002294+1532491</name>
+		<name>BD+54 1280</name>
+		<name>2MASS J09094881+5334056</name>
 		<magB errorminus="0.09" errorplus="0.09">11.33</magB>
 		<magV errorminus="0.05" errorplus="0.05">10.29</magV>
 		<magJ errorminus="0.046" errorplus="0.046">8.660</magJ>

--- a/systems/WASP-80.xml
+++ b/systems/WASP-80.xml
@@ -6,7 +6,7 @@
 	<star>
 		<name>WASP-80</name>
 		<name>2MASS J20124017-0208391</name>
-		<name>TYC 7038-834-1</name>
+		<name>TYC 5165-481-1</name>
 		<name>BPM 80815</name>
 		<name>GSC 05165-00481</name>
 		<temperature errorminus="100" errorplus="100">4145</temperature>
@@ -24,7 +24,7 @@
 		<planet>
 			<name>WASP-80 b</name>
 			<name>2MASS J20124017-0208391 b</name>
-			<name>TYC 7038-834-1 b</name>
+			<name>TYC 5165-481-1 b</name>
 			<name>BPM 80815 b</name>
 			<name>GSC 05165-00481 b</name>
 			<list>Confirmed planets</list>


### PR DESCRIPTION
Check for duplicate names indicated possible duplicates for two pairs of systems

* HD 233604 = BD+15 2940
* WASP-79 = WASP-80

These turned out to be due to incorrect designations in the files for HD 233604 and WASP-80, rather than being genuine duplicates.