### PR TITLE
Fix intra-system duplicate names

### DIFF
--- a/systems/55 Cancri.xml
+++ b/systems/55 Cancri.xml
@@ -162,7 +162,6 @@
 		</star>
 		<star>
 			<name>55 Cancri B</name>
-			<name>55 Cnc b</name>
 			<name>rho01 Cnc B</name>
 			<name>Rho-1 Cancri B</name>
 			<name>ρ1 Cnc B</name>

--- a/systems/BD-08 2823.xml
+++ b/systems/BD-08 2823.xml
@@ -23,7 +23,6 @@
 			<name>BD-08 2823 b</name>
 			<name>HIP 49067 b</name>
 			<name>TYC 5480-00020-1 b</name>
-			<name>BD-08 2823 b</name>
 			<name>2MASS J10004775-0931001 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.007" errorplus="0.007" type="msini">0.045</mass>
@@ -41,7 +40,6 @@
 			<name>BD-08 2823 c</name>
 			<name>HIP 49067 c</name>
 			<name>TYC 5480-00020-1 c</name>
-			<name>BD-08 2823 c</name>
 			<name>2MASS J10004775-0931001 c</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.03" errorplus="0.03" type="msini">0.33</mass>

--- a/systems/CoRoT-24.xml
+++ b/systems/CoRoT-24.xml
@@ -19,7 +19,7 @@
 		<spectraltype>K1V</spectraltype>
 		<planet>
 			<name>CoRoT-24 b</name>
-			<name>2MASS 06474141-0343094 c</name>
+			<name>2MASS 06474141-0343094 b</name>
 			<list>Confirmed planets</list>
 			<mass upperlimit="0.018" />
 			<radius errorminus="0.04" errorplus="0.04">0.33</radius>

--- a/systems/DP Leo.xml
+++ b/systems/DP Leo.xml
@@ -4,6 +4,7 @@
 	<declination>+17 57 41</declination>
 	<distance>400</distance>
 	<binary>
+		<name>DP Leo</name>
 		<period>0.0625</period>
 		<star>
 			<mass>0.6</mass>
@@ -11,12 +12,12 @@
 			<magV>17.5</magV>
 			<temperature>13500</temperature>
 			<spectraltype>AM Her</spectraltype>
-			<name>DP Leo</name>
+			<name>DP Leo A</name>
 		</star>
 		<star>
 			<mass>0.09</mass>
 			<temperature>3000</temperature>
-			<name>DP Leo</name>
+			<name>DP Leo B</name>
 		</star>
 		<planet>
 			<name>DP Leo b</name>

--- a/systems/EPIC 201549860.xml
+++ b/systems/EPIC 201549860.xml
@@ -7,7 +7,6 @@
 	<binary>
 		<name>EPIC 201549860</name>
 		<name>K2-35</name>
-		<name>2MASS J11202473+0117094</name>
 		<separation errorminus="0.05" errorplus="0.05" unit="arcsec">21.21</separation>
 		<star>
 			<name>EPIC 201549860 A</name>

--- a/systems/EPIC 220504338.xml
+++ b/systems/EPIC 220504338.xml
@@ -15,7 +15,8 @@
 		<temperature>5627.0</temperature>
 		<metallicity>0.18</metallicity>
 		<planet>
-			<name>EPIC 220504338</name>
+			<name>EPIC 220504338 b</name>
+			<name>K2-113 b</name>
 			<semimajoraxis errorminus="0.0057" errorplus="0.0074">0.0575</semimajoraxis>
 			<eccentricity>0.0</eccentricity>
 			<inclination errorminus="0.042" errorplus="0.54">86.44</inclination>

--- a/systems/GJ 536.xml
+++ b/systems/GJ 536.xml
@@ -12,7 +12,7 @@
 		<temperature>3685.0</temperature>
 		<metallicity>-0.08</metallicity>
 		<planet>
-			<name>GJ 536</name>
+			<name>GJ 536 b</name>
 			<semimajoraxis errorminus="1.3e-05" errorplus="1e-05">0.06661</semimajoraxis>
 			<periastron errorminus="50.6" errorplus="42.5">288.7</periastron>
 			<eccentricity errorminus="0.06" errorplus="0.09">0.08</eccentricity>

--- a/systems/Gliese 15.xml
+++ b/systems/Gliese 15.xml
@@ -25,7 +25,7 @@
 			<name>SAO 36248</name>
 			<name>GX Andromedae</name>
 			<name>GX And</name>
-			<name>Groombridge 34</name>
+			<name>Groombridge 34 A</name>
 			<name>BD+43 44 A</name>
 			<name>WDS J00184+4401 A</name>
 			<name>2MASS J00182256+4401222</name>
@@ -81,7 +81,6 @@
 			<spectraltype>M3.5</spectraltype>
 			<mass>0.163</mass>
 			<radius>0.19</radius>
-			<name>GQ And</name>
 		</star>
 	</binary>
 </system>

--- a/systems/Gliese 328.xml
+++ b/systems/Gliese 328.xml
@@ -13,7 +13,7 @@
 		<magH errorminus="0.018" errorplus="0.018">6.523</magH>
 		<magK errorminus="0.026" errorplus="0.026">6.352</magK>
 		<name>Gliese 328</name>
-		<name>GJ 328 b</name>
+		<name>GJ 328</name>
 		<mass errorminus="0.05" errorplus="0.05">0.69</mass>
 		<temperature errorminus="100" errorplus="100">3900</temperature>
 		<metallicity errorminus="0.15" errorplus="0.15">0.00</metallicity>

--- a/systems/Gliese 86.xml
+++ b/systems/Gliese 86.xml
@@ -70,7 +70,6 @@
 			<name>HD 13445 B</name>
 			<name>CD-51 532 B</name>
 			<name>CPD-51 282 B</name>
-			<name>2MASS J02102587-5049258</name>
 			<name>WDS J02104-5049 B</name>
 			<mass errorminus="0.01" errorplus="0.01">0.59</mass>
 			<radius errorminus="0.0015" errorplus="0.0015">0.01245</radius>

--- a/systems/HAT-P-30.xml
+++ b/systems/HAT-P-30.xml
@@ -29,7 +29,6 @@
 				<name>HAT-P-31 A b</name>
 				<name>WASP-51 b</name>
 				<name>WASP-51 A b</name>
-				<name>WASP-51</name>
 				<name>GSC 0208-00722 b</name>
 				<name>2MASS J08154797+0550121</name>
 				<list>Confirmed planets</list>

--- a/systems/HD 147513.xml
+++ b/systems/HD 147513.xml
@@ -25,7 +25,6 @@
 				<name>HD 147513 A b</name>
 				<name>62 G. Scorpii A b</name>
 				<name>HR 6094 A b</name>
-				<name>HD 147513 A</name>
 				<name>HD 147513 b</name>
 				<list>Confirmed planets</list>
 				<mass>1.21</mass>

--- a/systems/HD 220842.xml
+++ b/systems/HD 220842.xml
@@ -22,7 +22,7 @@
 		<temperature errorminus="20" errorplus="20">5960</temperature>
 		<mass errorminus="0.06" errorplus="0.06">1.13</mass>
 		<planet>
-			<name>HD 220842</name>
+			<name>HD 220842 b</name>
 			<list>Confirmed planets</list>
 			<period errorminus="0.19" errorplus="0.19">218.47</period>
 			<eccentricity errorminus="0.009" errorplus="0.009">0.404</eccentricity>

--- a/systems/HD 222076.xml
+++ b/systems/HD 222076.xml
@@ -10,7 +10,7 @@
 		<temperature>4806.0</temperature>
 		<metallicity>0.05</metallicity>
 		<planet>
-			<name>HD 222076</name>
+			<name>HD 222076 b</name>
 			<semimajoraxis errorminus="0.03" errorplus="0.03">1.83</semimajoraxis>
 			<periastron errorminus="60.0" errorplus="60.0">241.0</periastron>
 			<eccentricity errorminus="0.05" errorplus="0.05">0.08</eccentricity>

--- a/systems/HD 2638.xml
+++ b/systems/HD 2638.xml
@@ -20,7 +20,6 @@
 			<spectraltype>G0</spectraltype>
 		</star>
 		<binary>
-			<name>HD 2638</name>
 			<name>HD 2638 BC</name>
 			<separation errorminus="0.019" errorplus="0.019" unit="arcsec">0.526</separation>
 			<separation unit="AU">28.5</separation>

--- a/systems/HD 4732.xml
+++ b/systems/HD 4732.xml
@@ -20,7 +20,6 @@
 			<name>HD 4732 b</name>
 			<name>HR 228 b</name>
 			<name>HIP 3834 b</name>
-			<name>HD 4732 b</name>
 			<list>Confirmed planets</list>
 			<mass>2.37</mass>
 			<period>360.2</period>
@@ -35,7 +34,6 @@
 			<name>HD 4732 c</name>
 			<name>HR 228 c</name>
 			<name>HIP 3834 c</name>
-			<name>HD 4732 c</name>
 			<list>Confirmed planets</list>
 			<mass>2.37</mass>
 			<period>2732</period>

--- a/systems/HD 75784.xml
+++ b/systems/HD 75784.xml
@@ -26,7 +26,6 @@
 		<age errorminus="0.7" errorplus="0.7">4.0</age>
 		<planet>
 			<name>HD 75784 b</name>
-			<name>HD 75784 b</name>
 			<name>HIP 43569 b</name>
 			<name>TYC 817-1748-1 b</name>
 			<name>2MASS J08522396+1314005 b</name>

--- a/systems/HD 86950.xml
+++ b/systems/HD 86950.xml
@@ -13,7 +13,7 @@
 		<temperature>4805.0</temperature>
 		<metallicity>0.04</metallicity>
 		<planet>
-			<name>HD 86950</name>
+			<name>HD 86950 b</name>
 			<semimajoraxis errorminus="0.08" errorplus="0.08">2.72</semimajoraxis>
 			<periastron errorminus="70.0" errorplus="70.0">243.0</periastron>
 			<eccentricity errorminus="0.16" errorplus="0.16">0.17</eccentricity>

--- a/systems/HD 95086.xml
+++ b/systems/HD 95086.xml
@@ -18,7 +18,6 @@
 		<name>TYC 9212-4675-1</name>
 		<name>CD-68 847</name>
 		<name>CPD-68 1373</name>
-		<name>2MASS J10570301-6840023</name>
 		<name>SAO 251193</name>
 		<mass>1.7</mass>
 		<spectraltype errorminus="1">A8</spectraltype>

--- a/systems/HIP 65426.xml
+++ b/systems/HIP 65426.xml
@@ -11,7 +11,7 @@
 		<spectraltype>A2V</spectraltype>
 		<temperature>8840.0</temperature>
 		<planet>
-			<name>HIP 65426</name>
+			<name>HIP 65426 b</name>
 			<semimajoraxis>92.0</semimajoraxis>
 			<mass errorminus="3.0" errorplus="3.0">9.0</mass>
 			<radius errorminus="0.1" errorplus="0.1">1.5</radius>

--- a/systems/KELT-7.xml
+++ b/systems/KELT-7.xml
@@ -29,7 +29,7 @@
 			<name>HIP 24323 b</name>
 			<name>PPM 70046 b</name>
 			<name>TYC 2393-852-1 b</name>
-			<name>2MASS J05131092+331954</name>
+			<name>2MASS J05131092+331954 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.18" errorplus="0.18">1.28</mass>
 			<radius errorminus="0.047" errorplus="0.046">1.533</radius>

--- a/systems/KOI-2939.xml
+++ b/systems/KOI-2939.xml
@@ -14,7 +14,6 @@
 			<name>KOI-2939 AB</name>
 			<name>KIC 5473556 AB</name>
 			<name>Kepler-1647 AB</name>
-			<name>KIC 5473556</name>
 			<name>2MASS J19523602+4039222</name>
 			<magJ errorminus="0.024" errorplus="0.024">12.376</magJ>
 			<magH errorminus="0.026" errorplus="0.026">12.078</magH>

--- a/systems/Kepler-167.xml
+++ b/systems/Kepler-167.xml
@@ -84,7 +84,7 @@
 			<name>KOI-490 e</name>
 			<name>KOI-490.02</name>
 			<name>KIC 3239945 e</name>
-			<name>KIC 3239945.04</name>
+			<name>KIC 3239945.02</name>
 			<period errorminus="0.00056" errorplus="0.00056">1071.23228</period>
 			<transittime errorminus="0.00040" errorplus="0.00039" unit="BJD">2455253.28699</transittime>
 			<eccentricity errorminus="0.043" errorplus="0.104">0.062</eccentricity>

--- a/systems/Kepler-21.xml
+++ b/systems/Kepler-21.xml
@@ -11,7 +11,6 @@
 		<name>KIC 3632418</name>
 		<name>HD 179070</name>
 		<name>BD+38 3455</name>
-		<name>2MASS J19092683+3842505</name>
 		<separation errorminus="0.0099" errorplus="0.0099" unit="arcsec">0.7739</separation>
 		<separation errorminus="5.8" errorplus="5.8" unit="AU">87.3</separation>
 		<positionangle errorminus="0.63" errorplus="0.63">129.53</positionangle>
@@ -67,7 +66,7 @@
 		<star>
 			<name>Kepler-21 B</name>
 			<name>KOI-975 B</name>
-			<name>KIC 3632418 A</name>
+			<name>KIC 3632418 B</name>
 			<name>HD 179070 B</name>
 			<name>BD+38 3455 B</name>
 			<mass errorminus="0.32" errorplus="0.14">0.42</mass>

--- a/systems/Kepler-38.xml
+++ b/systems/Kepler-38.xml
@@ -35,7 +35,7 @@
 			<name>KIC 6762829 (AB) b</name>
 			<name>KOI-1740.02</name>
 			<name>KOI-1740 (AB) b</name>
-			<name>2MASS J19071928+4216451</name>
+			<name>2MASS J19071928+4216451 b</name>
 			<name>Kepler-38 b</name>
 			<name>KOI-1740 b</name>
 			<name>KIC 6762829 b</name>

--- a/systems/Kepler-444.xml
+++ b/systems/Kepler-444.xml
@@ -29,7 +29,6 @@
 			<name>KIC 6278762 A</name>
 			<name>LHS 3450 A</name>
 			<name>PPM 58152 A</name>
-			<name>TYC 3129-329-1</name>
 			<name>BD+41 3306 A</name>
 			<mass errorminus="0.043" errorplus="0.043">0.758</mass>
 			<radius errorminus="0.014" errorplus="0.014">0.752</radius>

--- a/systems/Kepler-63.xml
+++ b/systems/Kepler-63.xml
@@ -24,8 +24,6 @@
 			<name>KIC 11554435 b</name>
 			<name>KOI-63 b</name>
 			<name>KOI-63.01</name>
-			<name>KOI-63 b</name>
-			<name>KOI-63.01</name>
 			<list>Confirmed planets</list>
 			<mass upperlimit="0.377484" />
 			<radius errorminus="0.018226" errorplus="0.018226">0.556806</radius>

--- a/systems/Kepler-68.xml
+++ b/systems/Kepler-68.xml
@@ -9,7 +9,6 @@
 		<name>Kepler-68</name>
 		<name>KOI-246</name>
 		<name>KIC 11295426</name>
-		<name>2MASS J19240775+4902249</name>
 		<separation errorminus="0.030" errorplus="0.030" unit="arcsec">10.979</separation>
 		<separation errorminus="110" errorplus="110" unit="AU">1482</separation>
 		<positionangle errorminus="0.18" errorplus="0.18">145.43</positionangle>

--- a/systems/Kepler-74.xml
+++ b/systems/Kepler-74.xml
@@ -1,7 +1,7 @@
 <system>
 	<name>Kepler-74</name>
 	<name>KIC 6046540</name>
-	<name>2MASS 19322220+4121198</name>
+	<name>2MASS J19322220+4121198</name>
 	<name>KOI-200</name>
 	<rightascension>19 32 22</rightascension>
 	<declination>+41 21 20</declination>
@@ -11,7 +11,6 @@
 		<name>KOI-200</name>
 		<name>KIC 6046540</name>
 		<name>2MASS 19322220+4121198</name>
-		<name>KIC 6046540</name>
 		<name>2MASS J19322220+4121198</name>
 		<magB>14.5</magB>
 		<magV errorminus="0.17" errorplus="0.17">14.23</magV>

--- a/systems/Kepler-77.xml
+++ b/systems/Kepler-77.xml
@@ -33,7 +33,7 @@
 			<name>KOI-127 b</name>
 			<name>KOI-127.01</name>
 			<name>KIC 8359498 b</name>
-			<name>GSC2.3 N2K0000444</name>
+			<name>GSC2.3 N2K0000444 b</name>
 			<name>USNO-A2 1275-11111739 b</name>
 			<name>2MASS 19182590+4420435 b</name>
 			<radius errorminus="0.016" errorplus="0.016">0.96</radius>

--- a/systems/NY Virginis.xml
+++ b/systems/NY Virginis.xml
@@ -22,7 +22,6 @@
 		<star>
 			<name>NY Virginis B</name>
 			<name>NY Vir B</name>
-			<name>NY Virginis A</name>
 			<name>PG 1336-018 B</name>
 			<mass>0.14</mass>
 			<temperature>3000</temperature>

--- a/systems/OGLE-2014-BLG-0676L.xml
+++ b/systems/OGLE-2014-BLG-0676L.xml
@@ -7,7 +7,7 @@
 		<name>OGLE-2014-BLG-0676L</name>
 		<mass>0.62</mass>
 		<planet>
-			<name>OGLE-2014-BLG-0676L</name>
+			<name>OGLE-2014-BLG-0676L b</name>
 			<semimajoraxis errorminus="1.46" errorplus="2.16">4.4</semimajoraxis>
 			<mass errorminus="1.12" errorplus="1.02">3.09</mass>
 			<discoveryyear>2016</discoveryyear>

--- a/systems/Psi-1 Draconis.xml
+++ b/systems/Psi-1 Draconis.xml
@@ -77,7 +77,7 @@
 				<name>HD 162003 B</name>
 				<name>HIP 86614 B</name>
 				<name>TYC 4436-1425-1 B</name>
-				<name>SAO 8890 A</name>
+				<name>SAO 8890 B</name>
 				<name>HR 6636 B</name>
 				<name>Gliese 694.1 C</name>
 				<name>GJ 694.1 C</name>

--- a/systems/SDSS J1110+0116.xml
+++ b/systems/SDSS J1110+0116.xml
@@ -3,21 +3,17 @@
 	<rightascension>11 10 10</rightascension>
 	<declination>+01 16 13</declination>
 	<distance>19.19</distance>
-	<star>
+	<planet>
 		<name>SDSS J1110+0116</name>
+		<mass errorminus="1.0" errorplus="1.0">11.0</mass>
+		<radius errorminus="0.02" errorplus="0.02">1.18</radius>
 		<age>0.12</age>
 		<spectraltype>T5.5</spectraltype>
 		<temperature>940.0</temperature>
-		<planet>
-			<name>SDSS J1110+0116</name>
-			<mass errorminus="1.0" errorplus="1.0">11.0</mass>
-			<radius errorminus="0.02" errorplus="0.02">1.18</radius>
-			<istransiting>1</istransiting>
-			<discoverymethod>imaging</discoverymethod>
-			<discoveryyear>2015</discoveryyear>
-			<lastupdate>17/07/02</lastupdate>
-			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
-		</planet>
-	</star>
+		<discoverymethod>imaging</discoverymethod>
+		<discoveryyear>2015</discoveryyear>
+		<lastupdate>17/07/02</lastupdate>
+		<list>Confirmed planets</list>
+		<description>Data for this planet was imported from the exoplanet.eu database.</description>
+	</planet>
 </system>

--- a/systems/SIMP0136+0933.xml
+++ b/systems/SIMP0136+0933.xml
@@ -3,19 +3,16 @@
 	<rightascension>01 36 57</rightascension>
 	<declination>+09 33 47</declination>
 	<distance>6.0</distance>
-	<star>
+	<planet>
 		<name>SIMP0136+0933</name>
+		<mass errorminus="1.0" errorplus="1.0">12.7</mass>
 		<age>0.2</age>
 		<spectraltype>T2.5</spectraltype>
 		<temperature>1098.0</temperature>
-		<planet>
-			<name>SIMP0136+0933</name>
-			<mass errorminus="1.0" errorplus="1.0">12.7</mass>
-			<discoverymethod>imaging</discoverymethod>
-			<discoveryyear>2017</discoveryyear>
-			<lastupdate>17/07/02</lastupdate>
-			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
-		</planet>
-	</star>
+		<discoverymethod>imaging</discoverymethod>
+		<discoveryyear>2017</discoveryyear>
+		<lastupdate>17/07/02</lastupdate>
+		<list>Confirmed planets</list>
+		<description>Data for this planet was imported from the exoplanet.eu database.</description>
+	</planet>
 </system>

--- a/systems/TrES-4.xml
+++ b/systems/TrES-4.xml
@@ -26,8 +26,8 @@
 			<planet>
 				<name>TrES-4 A b</name>
 				<name>TrES-4 b</name>
-				<name>TYC 2620-00648-1</name>
-				<name>2MASS J17531304+3712426</name>
+				<name>TYC 2620-00648-1 b</name>
+				<name>2MASS J17531304+3712426 b</name>
 				<name>TrES-4</name>
 				<list>Confirmed planets</list>
 				<list>Planets in binary systems, S-type</list>

--- a/systems/WASP-75.xml
+++ b/systems/WASP-75.xml
@@ -18,7 +18,6 @@
 		<spectraltype>F9</spectraltype>
 		<planet>
 			<name>WASP-75 b</name>
-			<name>WASP-75</name>
 			<name>1SWASP J224932.56-104031.8 b</name>
 			<list>Confirmed planets</list>
 			<mass errorminus="0.05" errorplus="0.05">1.07</mass>

--- a/systems/alf Tau.xml
+++ b/systems/alf Tau.xml
@@ -6,8 +6,8 @@
 	<declination>+16 30 35.1</declination>
 	<distance errorminus="0.32" errorplus="0.32">20.43</distance>
 	<binary>
-		<name>alf Tau</name>
-		<name>Aldebaran</name>
+		<name>alf Tau AB</name>
+		<name>Aldebaran AB</name>
 		<name>Alpha Tauri</name>
 		<name>α Tau</name>
 		<name>α Tauri</name>


### PR DESCRIPTION
Fix duplicate names appearing in the same system.

For now I'm leaving the ambiguous cases of TrES-n and SWEEPS-n, where these designations have been used for both the planet and the star.