### PR TITLE
Add/update open cluster planets

### DIFF
--- a/systems/EPIC 211822797.xml
+++ b/systems/EPIC 211822797.xml
@@ -1,28 +1,37 @@
 <system>
 	<name>EPIC 211822797</name>
 	<name>K2-103</name>
-	<rightascension>08 41 38</rightascension>
-	<declination>+17 38 24</declination>
+	<rightascension>08 41 38.483</rightascension>
+	<declination>+17 38 24.05</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
 	<star>
 		<name>EPIC 211822797</name>
 		<name>K2-103</name>
 		<name>2MASS J08413848+1738240</name>
-		<age>0.8</age>
-		<radius>0.59</radius>
-		<mass>0.61</mass>
-		<temperature>3880.0</temperature>
+		<magJ errorminus="0.001" errorplus="0.001">12.264</magJ>
+		<magH errorminus="0.001" errorplus="0.001">11.699</magH>
+		<magK errorminus="0.001" errorplus="0.001">11.432</magK>
+		<spectraltype>M0.4</spectraltype>
+		<radius errorminus="0.03" errorplus="0.03">0.59</radius>
+		<mass errorminus="0.02" errorplus="0.02">0.61</mass>
+		<temperature errorminus="67" errorplus="67">3880</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
 		<planet>
 			<name>EPIC 211822797 b</name>
 			<name>K2-103 b</name>
 			<eccentricity errorminus="0.15" errorplus="0.27">0.18</eccentricity>
 			<inclination errorminus="0.4" errorplus="0.3">89.5</inclination>
 			<period errorminus="0.001729" errorplus="0.001665">21.169619</period>
-			<radius errorminus="0.0089" errorplus="0.018">0.2</radius>
+			<radius errorminus="0.0089" errorplus="0.018">0.196</radius>
+			<periastron errorminus="67" errorplus="156">0</periastron>
+			<transittime errorminus="0.00430" errorplus="0.00443" unit="BJD">2457123.23803</transittime>
 			<istransiting>1</istransiting>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/09/07</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
+			<list>Planets in open clusters</list>
+			<description>K2-103b is a sub-Neptune exoplanet in the Praesepe cluster.</description>
 		</planet>
 	</star>
 </system>

--- a/systems/EPIC 211901114.xml
+++ b/systems/EPIC 211901114.xml
@@ -1,0 +1,36 @@
+<system>
+	<name>EPIC 211901114</name>
+	<rightascension>08 41 35.694</rightascension>
+	<declination>18 44 35.01</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
+	<star>
+		<name>EPIC 211901114</name>
+		<name>2MASS J08413569+1844350</name>
+		<magB>19.59</magB>
+		<magV>17.14</magV>
+		<magJ errorminus="0.002" errorplus="0.002">13.129</magJ>
+		<magH errorminus="0.001" errorplus="0.001">12.549</magH>
+		<magK errorminus="0.001" errorplus="0.001">12.290</magK>
+		<spectraltype>M2.7</spectraltype>
+		<mass errorminus="0.02" errorplus="0.02">0.46</mass>
+		<radius errorminus="0.02" errorplus="0.02">0.46</radius>
+		<temperature errorminus="65" errorplus="65">3440</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
+		<planet>
+			<name>EPIC 211901114 b</name>
+			<list>Controversial</list>
+			<list>Planets in open clusters</list>
+			<period errorminus="0.000069" errorplus="0.000071">1.648932</period>
+			<transittime errorminus="0.00200" errorplus="0.00191" unit="BJD">2457140.83259</transittime>
+			<inclination errorminus="0.7" errorplus="0.7">83.5</inclination>
+			<radius errorminus="0.428" errorplus="0.473">0.856</radius>
+			<mass type="msini" upperlimit="5" />
+			<istransiting>1</istransiting>
+			<discoverymethod>transit</discoverymethod>
+			<discoveryyear>2016</discoveryyear>
+			<description>EPIC 211901114 b is a candidate exoplanet in the Praesepe cluster. If confirmed, it would be one of the few known examples of a hot Jupiter orbiting a red dwarf star.</description>
+			<lastupdate>18/03/23</lastupdate>
+		</planet>
+	</star>
+</system>

--- a/systems/EPIC 211913977.xml
+++ b/systems/EPIC 211913977.xml
@@ -1,28 +1,39 @@
 <system>
 	<name>EPIC 211913977</name>
 	<name>K2-101</name>
-	<rightascension>08 41 23</rightascension>
-	<declination>+18 56 02</declination>
+	<rightascension>08 41 22.581</rightascension>
+	<declination>+18 56 02.08</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
 	<star>
 		<name>EPIC 211913977</name>
 		<name>K2-101</name>
 		<name>2MASS J08412258+1856020</name>
-		<age>0.8</age>
-		<radius>0.73</radius>
-		<mass>0.8</mass>
-		<temperature>4819.0</temperature>
+		<magB>14.00</magB>
+		<magV>12.96</magV>
+		<magJ errorminus="0.023" errorplus="0.023">11.162</magJ>
+		<magH errorminus="0.022" errorplus="0.022">10.678</magH>
+		<magK errorminus="0.019" errorplus="0.019">10.536</magK>
+		<spectraltype>K3V</spectraltype>
+		<mass errorminus="0.06" errorplus="0.06">0.80</mass>
+		<radius errorminus="0.03" errorplus="0.03">0.73</radius>
+		<temperature errorminus="45" errorplus="45">4819</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
 		<planet>
 			<name>EPIC 211913977 b</name>
 			<name>K2-101 b</name>
-			<eccentricity errorminus="0.08" errorplus="0.18">0.1</eccentricity>
+			<eccentricity errorminus="0.08" errorplus="0.18">0.10</eccentricity>
 			<inclination errorminus="0.5" errorplus="0.4">89.4</inclination>
 			<period errorminus="0.000804" errorplus="0.000828">14.677286</period>
-			<radius errorminus="0.0089" errorplus="0.0089">0.18</radius>
+			<radius errorminus="0.0089" errorplus="0.0089">0.178</radius>
+			<periastron errorminus="118" errorplus="152">0</periastron>
+			<transittime errorminus="0.00230" errorplus="0.00223" unit="BJD">2457152.68135</transittime>
 			<istransiting>1</istransiting>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/09/07</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
+			<list>Planets in open clusters</list>
+			<description>K2-101 b is a sub-Neptune exoplanet located in the Praesepe cluster.</description>
 		</planet>
 	</star>
 </system>

--- a/systems/EPIC 211916756.xml
+++ b/systems/EPIC 211916756.xml
@@ -4,6 +4,7 @@
 	<name>JS 183</name>
 	<rightascension>08 37 27.058</rightascension>
 	<declination>+18 58 36.07</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
 	<star>
 		<name>EPIC 211916756</name>
 		<name>K2-95</name>
@@ -14,10 +15,12 @@
 		<magJ errorminus="0.002" errorplus="0.002">13.293</magJ>
 		<magH errorminus="0.002" errorplus="0.002">12.740</magH>
 		<magK errorminus="0.001" errorplus="0.001">12.442</magK>
-		<age>0.8</age>
-		<radius errorminus="0.02" errorplus="0.02">0.44</radius>
+		<spectraltype>M2.0</spectraltype>
 		<mass errorminus="0.02" errorplus="0.02">0.43</mass>
+		<radius errorminus="0.02" errorplus="0.02">0.44</radius>
 		<temperature errorminus="65" errorplus="65">3410</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
 		<planet>
 			<name>EPIC 211916756 b</name>
 			<name>K2-95 b</name>
@@ -31,7 +34,7 @@
 			<transittime errorminus="0.00208" errorplus="0.00205" unit="BJD">2457140.74083</transittime>
 			<istransiting>1</istransiting>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>18/02/17</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
 			<description>K2-95 b is a Neptune-sized exoplanet in the Praesepe cluster.</description>

--- a/systems/EPIC 211969807.xml
+++ b/systems/EPIC 211969807.xml
@@ -1,28 +1,39 @@
 <system>
 	<name>EPIC 211969807</name>
 	<name>K2-104</name>
-	<rightascension>08 38 33</rightascension>
-	<declination>+19 46 26</declination>
+	<rightascension>08 38 32.834</rightascension>
+	<declination>+19 46 25.67</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
 	<star>
 		<name>EPIC 211969807</name>
 		<name>K2-104</name>
 		<name>2MASS J08383283+1946256</name>
-		<age>0.8</age>
-		<radius>0.48</radius>
-		<mass>0.51</mass>
-		<temperature>3660.0</temperature>
+		<magB>18.46</magB>
+		<magV>16.26</magV>
+		<magJ errorminus="0.002" errorplus="0.002">12.800</magJ>
+		<magH errorminus="0.001" errorplus="0.001">12.246</magH>
+		<magK errorminus="0.001" errorplus="0.001">12.021</magK>
+		<spectraltype>M1.2</spectraltype>
+		<radius errorminus="0.02" errorplus="0.02">0.48</radius>
+		<mass errorminus="0.02" errorplus="0.02">0.51</mass>
+		<temperature errorminus="67" errorplus="67">3660</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
 		<planet>
 			<name>EPIC 211969807 b</name>
 			<name>K2-104 b</name>
 			<eccentricity errorminus="0.14" errorplus="0.29">0.18</eccentricity>
 			<inclination errorminus="1.9" errorplus="1.4">88.0</inclination>
 			<period errorminus="0.000110" errorplus="0.000110">1.97419</period>
-			<radius errorminus="0.018" errorplus="0.0089">0.17</radius>
+			<radius errorminus="0.018" errorplus="0.0089">0.170</radius>
+			<periastron errorminus="63" errorplus="155">0</periastron>
+			<transittime errorminus="0.00261" errorplus="0.00268" unit="BJD">2457140.38117</transittime>
 			<istransiting>1</istransiting>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/09/07</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
+			<list>Planets in open clusters</list>
+			<description>K2-104b is a sub-Neptune exoplanet in the Praesepe cluster.</description>
 		</planet>
 	</star>
 </system>

--- a/systems/EPIC 211970147.xml
+++ b/systems/EPIC 211970147.xml
@@ -1,28 +1,39 @@
 <system>
 	<name>EPIC 211970147</name>
 	<name>K2-102</name>
-	<rightascension>08 40 13</rightascension>
-	<declination>+19 46 44</declination>
+	<rightascension>08 40 13.453</rightascension>
+	<declination>+19 46 43.65</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
 	<star>
 		<name>EPIC 211970147</name>
 		<name>K2-102</name>
 		<name>2MASS J08401345+1946436</name>
-		<age>0.8</age>
-		<radius>0.71</radius>
-		<mass>0.77</mass>
-		<temperature>4695.0</temperature>
+		<magB>14.30</magB>
+		<magV>13.19</magV>
+		<magJ errorminus="0.022" errorplus="0.022">11.282</magJ>
+		<magH errorminus="0.020" errorplus="0.020">10.739</magH>
+		<magK errorminus="0.020" errorplus="0.020">10.640</magK>
+		<spectraltype>K3.6</spectraltype>
+		<radius errorminus="0.03" errorplus="0.03">0.71</radius>
+		<mass errorminus="0.06" errorplus="0.06">0.77</mass>
+		<temperature errorminus="50" errorplus="50">4695</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
 		<planet>
 			<name>EPIC 211970147 b</name>
 			<name>K2-102 b</name>
-			<eccentricity errorminus="0.07" errorplus="0.16">0.1</eccentricity>
+			<eccentricity errorminus="0.07" errorplus="0.16">0.10</eccentricity>
 			<inclination errorminus="0.6" errorplus="0.6">89.0</inclination>
 			<period errorminus="0.001195" errorplus="0.001209">9.915615</period>
-			<radius errorminus="0.0089" errorplus="0.0089">0.12</radius>
+			<radius errorminus="0.0089" errorplus="0.0089">0.116</radius>
+			<periastron errorminus="132" errorplus="136">-1</periastron>
+			<transittime errorminus="0.00552" errorplus="0.00552" unit="BJD">2457139.65518</transittime>
 			<istransiting>1</istransiting>
 			<discoveryyear>2016</discoveryyear>
 			<lastupdate>16/09/07</lastupdate>
 			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
+			<list>Planets in open clusters</list>
+			<description>K2-102 b is a super-Earth located in the Praesepe cluster.</description>
 		</planet>
 	</star>
 </system>

--- a/systems/EPIC 211990866.xml
+++ b/systems/EPIC 211990866.xml
@@ -3,26 +3,38 @@
 	<name>K2-100</name>
 	<rightascension>08 38 24</rightascension>
 	<declination>+20 06 22</declination>
+	<distance errorminus="6.0" errorplus="6.0">181.5</distance>
 	<star>
 		<name>EPIC 211990866</name>
 		<name>K2-100</name>
+		<name>TYC 1398-142-1</name>
 		<name>2MASS J08382429+2006217</name>
-		<age>0.8</age>
-		<radius>1.19</radius>
-		<mass>1.18</mass>
-		<temperature>6120.0</temperature>
+		<magB>11.13</magB>
+		<magV>10.55</magV>
+		<magJ errorminus="0.026" errorplus="0.026">9.463</magJ>
+		<magH errorminus="0.030" errorplus="0.030">9.242</magH>
+		<magK errorminus="0.018" errorplus="0.018">9.182</magK>
+		<spectraltype>G0V</spectraltype>
+		<mass errorminus="0.09" errorplus="0.09">1.18</mass>
+		<radius errorminus="0.05" errorplus="0.05">1.19</radius>
+		<temperature errorminus="90" errorplus="90">6120</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.030" errorplus="0.030">0.790</age>
 		<planet>
 			<name>EPIC 211990866 b</name>
 			<name>K2-100 b</name>
 			<eccentricity errorminus="0.12" errorplus="0.19">0.24</eccentricity>
 			<inclination errorminus="3.1" errorplus="3.3">85.1</inclination>
 			<period errorminus="0.000013" errorplus="0.000012">1.673916</period>
-			<radius errorminus="0.018" errorplus="0.018">0.31</radius>
+			<radius errorminus="0.018" errorplus="0.018">0.312</radius>
+			<periastron errorminus="33" errorplus="41">29</periastron>
+			<transittime errorminus="0.00037" errorplus="0.00055" unit="BJD">2457144.06723</transittime>
 			<istransiting>1</istransiting>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/09/07</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<list>Confirmed planets</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
+			<list>Planets in open clusters</list>
+			<description>K2-100 b is a sub-Neptune exoplanet located in the Praesepe cluster.</description>
 		</planet>
 	</star>
 </system>

--- a/systems/HD 285507.xml
+++ b/systems/HD 285507.xml
@@ -1,24 +1,25 @@
 <system>
 	<name>HD 285507</name>
-	<rightascension>04 07 01</rightascension>
-	<declination>+15 20 06</declination>
-	<distance>41.339</distance>
+	<rightascension>04 07 01.2257</rightascension>
+	<declination>+15 20 06.107</declination>
+	<distance errorminus="0.56" errorplus="0.56">44.70</distance>
 	<star>
-		<magB>11.8</magB>
-		<magV>10.5</magV>
+		<name>HD 285507</name>
+		<name>HIP 19207</name>
+		<name>TYC 1250-4-1</name>
+		<name>BD+14 653</name>
+		<name>2MASS J04070122+1520062</name>
+		<magB errorminus="0.010" errorplus="0.010">11.670</magB>
+		<magV errorminus="0.012" errorplus="0.012">10.473</magV>
 		<magJ errorminus="0.026" errorplus="0.026">8.365</magJ>
 		<magH errorminus="0.049" errorplus="0.049">7.811</magH>
 		<magK errorminus="0.026" errorplus="0.026">7.665</magK>
-		<name>HD 285507</name>
-		<name>HIP 19207</name>
-		<name>2MASS J04070122+1520062</name>
-		<name>BD+14 653</name>
 		<mass errorminus="0.034" errorplus="0.034">0.734</mass>
 		<radius errorminus="0.054" errorplus="0.054">0.656</radius>
 		<temperature errorminus="61" errorplus="85">4503</temperature>
 		<metallicity errorminus="0.01" errorplus="0.01">0.13</metallicity>
 		<age errorminus="0.05" errorplus="0.05">0.625</age>
-		<spectraltype>K5 D</spectraltype>
+		<spectraltype>K4</spectraltype>
 		<planet>
 			<name>HD 285507 b</name>
 			<name>HIP 19207 b</name>
@@ -26,13 +27,15 @@
 			<name>BD+14 653 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass errorminus="0.033" errorplus="0.033">0.917</mass>
+			<mass errorminus="0.033" errorplus="0.033" type="msini">0.917</mass>
 			<period errorminus="0.0018" errorplus="0.0018">6.0881</period>
 			<eccentricity errorminus="0.019" errorplus="0.019">0.086</eccentricity>
 			<periastron errorminus="11" errorplus="11">182</periastron>
+			<transittime errorminus="0.029" errorplus="0.029" unit="BJD">2456263.121</transittime>
+			<istransiting>0</istransiting>
 			<description>HD 285507b is a Hot Jupiter that joins the small but growing list of planets in open clusters. HD 285507b orbits a star in the Hyades cluster.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>13/10/29</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 		</planet>
 	</star>

--- a/systems/K2-136.xml
+++ b/systems/K2-136.xml
@@ -1,0 +1,109 @@
+<system>
+	<name>K2-136</name>
+	<name>EPIC 247589423</name>
+	<name>LP 358-348</name>
+	<rightascension>04 29 38.993</rightascension>
+	<declination>+22 52 57.80</declination>
+	<distance errorminus="2.8" errorplus="2.8">59.4</distance>
+	<binary>
+		<name>K2-136</name>
+		<name>EPIC 247589423</name>
+		<name>LP 358-348</name>
+		<name>2MASS J04293897+2252579</name>
+		<separation unit="arcsec">0.730</separation>
+		<separation unit="AU">43</separation>
+		<positionangle>7.9</positionangle>
+		<star>
+			<name>K2-136 A</name>
+			<name>EPIC 247589423 A</name>
+			<name>LP 358-348 A</name>
+			<name>2MASS J04293897+2252579 A</name>
+			<magJ errorminus="0.04" errorplus="0.04">9.11</magJ>
+			<magH errorminus="0.02" errorplus="0.02">8.51</magH>
+			<magK errorminus="0.02" errorplus="0.02">8.38</magK>
+			<spectraltype errorminus="1">K5V</spectraltype>
+			<temperature errorminus="50" errorplus="50">4499</temperature>
+			<metallicity errorminus="0.03" errorplus="0.03">0.15</metallicity>
+			<mass errorminus="0.02" errorplus="0.02">0.74</mass>
+			<radius errorminus="0.02" errorplus="0.02">0.66</radius>
+			<planet>
+				<name>K2-136 b</name>
+				<name>K2-136 A b</name>
+				<name>EPIC 247589423 b</name>
+				<name>EPIC 247589423 A b</name>
+				<name>LP 358-348 b</name>
+				<name>LP 358-348 A b</name>
+				<period errorminus="0.000770" errorplus="0.000833">7.975292</period>
+				<transittime errorminus="0.00489" errorplus="0.00469" unit="BJD">2457817.75631</transittime>
+				<inclination errorminus="0.7" errorplus="0.5">89.3</inclination>
+				<eccentricity errorminus="0.07" errorplus="0.19">0.10</eccentricity>
+				<periastron errorminus="70" errorplus="145">12</periastron>
+				<radius errorminus="0.0036" errorplus="0.0054">0.0883</radius>
+				<istransiting>1</istransiting>
+				<discoverymethod>transit</discoverymethod>
+				<discoveryyear>2017</discoveryyear>
+				<description>K2-136 is a binary star located in the Hyades open cluster. The system contains three known planets and was independently discovered by Ciardi et al., Mann et al. and Livingston et al.</description>
+				<lastupdate>18/03/23</lastupdate>
+				<list>Confirmed planets</list>
+				<list>Planets in open clusters</list>
+				<list>Planets in binary systems, S-type</list>
+			</planet>
+			<planet>
+				<name>K2-136 c</name>
+				<name>K2-136 A c</name>
+				<name>EPIC 247589423 c</name>
+				<name>EPIC 247589423 A c</name>
+				<name>LP 358-348 c</name>
+				<name>LP 358-348 A c</name>
+				<period errorminus="0.000284" errorplus="0.000252">17.307137</period>
+				<transittime errorminus="0.00077" errorplus="0.00100" unit="BJD">2457812.71770</transittime>
+				<inclination errorminus="0.3" errorplus="0.3">89.6</inclination>
+				<eccentricity errorminus="0.11" errorplus="0.27">0.13</eccentricity>
+				<periastron errorminus="74" errorplus="141">24</periastron>
+				<radius errorminus="0.0089" errorplus="0.0098">0.2596</radius>
+				<istransiting>1</istransiting>
+				<discoverymethod>transit</discoverymethod>
+				<discoveryyear>2017</discoveryyear>
+				<description>K2-136 is a binary star located in the Hyades open cluster. The system contains three known planets and was independently discovered by Ciardi et al., Mann et al. and Livingston et al.</description>
+				<lastupdate>18/03/23</lastupdate>
+				<list>Confirmed planets</list>
+				<list>Planets in open clusters</list>
+				<list>Planets in binary systems, S-type</list>
+			</planet>
+			<planet>
+				<name>K2-136 d</name>
+				<name>K2-136 A d</name>
+				<name>EPIC 247589423 d</name>
+				<name>EPIC 247589423 A d</name>
+				<name>LP 358-348 d</name>
+				<name>LP 358-348 A d</name>
+				<period errorminus="0.002357" errorplus="0.002418">25.575065</period>
+				<transittime errorminus="0.00660" errorplus="0.00643" unit="BJD">2457780.81164</transittime>
+				<inclination errorminus="0.2" errorplus="0.4">89.4</inclination>
+				<eccentricity errorminus="0.09" errorplus="0.13">0.14</eccentricity>
+				<periastron errorminus="148" errorplus="91">2</periastron>
+				<radius errorminus="0.0071" errorplus="0.0098">0.1294</radius>
+				<istransiting>1</istransiting>
+				<discoverymethod>transit</discoverymethod>
+				<discoveryyear>2017</discoveryyear>
+				<description>K2-136 is a binary star located in the Hyades open cluster. The system contains three known planets and was independently discovered by Ciardi et al., Mann et al. and Livingston et al.</description>
+				<lastupdate>18/03/23</lastupdate>
+				<list>Confirmed planets</list>
+				<list>Planets in open clusters</list>
+				<list>Planets in binary systems, S-type</list>
+			</planet>
+		</star>
+		<star>
+			<name>K2-136 B</name>
+			<name>EPIC 247589423 B</name>
+			<name>LP 358-348 B</name>
+			<name>2MASS J04293897+2252579 B</name>
+			<magJ errorminus="0.1" errorplus="0.1">14.1</magJ>
+			<magH errorminus="0.04" errorplus="0.04">13.47</magH>
+			<magK errorminus="0.03" errorplus="0.03">13.03</magK>
+			<spectraltype>M7/8V</spectraltype>
+			<mass>0.1</mass>
+			<radius>0.1</radius>
+		</star>
+	</binary>
+</system>

--- a/systems/K2-231.xml
+++ b/systems/K2-231.xml
@@ -1,0 +1,37 @@
+<system>
+	<name>K2-231</name>
+	<name>EPIC 219800881</name>
+	<rightascension>19 16 22.039</rightascension>
+	<declination>-15 46 15.99</declination>
+	<distance errorminus="5" errorplus="5">295</distance>
+	<star>
+		<name>K2-231</name>
+		<name>EPIC 219800881</name>
+		<name>2MASS J19162203-1546159</name>
+		<magB errorminus="0.030" errorplus="0.030">13.500</magB>
+		<magV errorminus="0.040" errorplus="0.040">12.708</magV>
+		<magJ errorminus="0.024" errorplus="0.024">11.294</magJ>
+		<magH errorminus="0.026" errorplus="0.026">11.004</magH>
+		<magK errorminus="0.023" errorplus="0.023">10.859</magK>
+		<mass errorminus="0.03" errorplus="0.03">1.01</mass>
+		<radius errorminus="0.03" errorplus="0.03">0.95</radius>
+		<temperature errorminus="50" errorplus="50">5695</temperature>
+		<metallicity errorminus="0.04" errorplus="0.04">0.14</metallicity>
+		<age errorminus="0.25" errorplus="0.25">3</age>
+		<planet>
+			<name>K2-231 b</name>
+			<name>EPIC 219800881 b</name>
+			<list>Confirmed planets</list>
+			<list>Planets in open clusters</list>
+			<period errorminus="0.001352" errorplus="0.001352">13.841901</period>
+			<inclination errorminus="0.6" errorplus="0.9">88.6</inclination>
+			<transittime errorminus="0.00340" errorplus="0.00354" unit="BJD">2457320.00164</transittime>
+			<radius errorminus="0.018" errorplus="0.018">0.223</radius>
+			<istransiting>1</istransiting>
+			<discoverymethod>transit</discoverymethod>
+			<discoveryyear>2018</discoveryyear>
+			<description>K2-231 b is a sub-Neptune exoplanet orbiting a solar twin in the old open cluster Ruprecht 147.</description>
+			<lastupdate>18/03/23</lastupdate>
+		</planet>
+	</star>
+</system>

--- a/systems/Kepler-66.xml
+++ b/systems/Kepler-66.xml
@@ -2,8 +2,8 @@
 	<name>Kepler-66</name>
 	<name>KOI-1958</name>
 	<name>KIC 9836149</name>
-	<rightascension>19 35 56</rightascension>
-	<declination>+46 41 16</declination>
+	<rightascension>19 35 55.576</rightascension>
+	<declination>+46 41 15.97</declination>
 	<distance errorminus="90" errorplus="90">1107</distance>
 	<star>
 		<name>Kepler-66</name>
@@ -20,7 +20,7 @@
 		<magK errorminus="0.04" errorplus="0.04">13.62</magK>
 		<metallicity errorminus="0.003" errorplus="0.003">0.012</metallicity>
 		<spectraltype>G0V</spectraltype>
-		<age errorminus="0.17" errorplus="0.17">1</age>
+		<age errorminus="0.17" errorplus="0.17">1.00</age>
 		<planet>
 			<name>Kepler-66 b</name>
 			<name>KOI-1958.01</name>
@@ -28,13 +28,14 @@
 			<name>KIC 9836149 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<radius errorminus="0.014581" errorplus="0.014581">0.255165</radius>
+			<radius errorminus="0.0143" errorplus="0.0143">0.2498</radius>
 			<period errorminus="0.000075" errorplus="0.000075">17.815815</period>
 			<transittime errorminus="0.0025" errorplus="0.0025">2454967.4854</transittime>
 			<semimajoraxis errorminus="0.0017" errorplus="0.0017">0.1352</semimajoraxis>
+			<impactparameter errorminus="0.26" errorplus="0.26">0.56</impactparameter>
 			<discoverymethod>transit</discoverymethod>
 			<description>Kepler-66 b is orbiting a Sun-like star in the billion-year-old open cluster NGC6811. It demonstrates that small planets can form and survive in a dense cluster environment. The frequency of planets around stars in open cluster and field stars in the Milky Way are approximately the same.</description>
-			<lastupdate>13/06/26</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2013</discoveryyear>
 			<istransiting>1</istransiting>
 		</planet>

--- a/systems/Kepler-67.xml
+++ b/systems/Kepler-67.xml
@@ -2,8 +2,8 @@
 	<name>Kepler-67</name>
 	<name>KOI-2115</name>
 	<name>KIC 9532052</name>
-	<rightascension>19 36 37</rightascension>
-	<declination>+46 09 59</declination>
+	<rightascension>19 36 36.801</rightascension>
+	<declination>+46 09 59.19</declination>
 	<distance errorminus="90" errorplus="90">1107</distance>
 	<star>
 		<name>Kepler-67</name>
@@ -19,7 +19,7 @@
 		<magK errorminus="0.065" errorplus="0.065">14.155</magK>
 		<metallicity errorminus="0.003" errorplus="0.003">0.012</metallicity>
 		<spectraltype>G9V</spectraltype>
-		<age errorminus="0.17" errorplus="0.17">1</age>
+		<age errorminus="0.17" errorplus="0.17">1.00</age>
 		<planet>
 			<name>Kepler-67 b</name>
 			<name>KOI-2115.01</name>
@@ -27,12 +27,13 @@
 			<name>KIC 9532052 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<radius errorminus="0.014581" errorplus="0.014581">0.267923</radius>
+			<radius errorminus="0.0143" errorplus="0.0143">0.2623</radius>
 			<period errorminus="0.00011" errorplus="0.00011">15.72590</period>
 			<transittime errorminus="0.0048" errorplus="0.0048">2454966.9855</transittime>
 			<semimajoraxis errorminus="0.0015" errorplus="0.0015">0.1171</semimajoraxis>
+			<impactparameter errorminus="0.21" errorplus="0.21">0.37</impactparameter>
 			<discoverymethod>transit</discoverymethod>
-			<lastupdate>13/06/26</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<description>Kepler-67 b is orbiting a Sun-like star in the billion-year-old open cluster NGC6811. It demonstrates that small planets can form and survive in a dense cluster environment. The frequency of planets around stars in open cluster and field stars in the Milky Way are approximately the same.</description>
 			<discoveryyear>2013</discoveryyear>
 			<istransiting>1</istransiting>

--- a/systems/NGC 2423 3.xml
+++ b/systems/NGC 2423 3.xml
@@ -1,33 +1,40 @@
 <system>
 	<name>NGC 2423 3</name>
-	<rightascension>07 37 09</rightascension>
-	<declination>-13 54 24</declination>
+	<name>NGC 2423 MMU 3</name>
+	<rightascension>07 37 09.2328</rightascension>
+	<declination>-13 54 23.952</declination>
 	<distance>766</distance>
 	<star>
 		<name>NGC 2423 3</name>
+		<name>NGC 2423 MMU 3</name>
 		<name>BD-13 2130</name>
-		<spectraltype>GIV/V</spectraltype>
-		<mass>2.4</mass>
-		<magV>9.45</magV>
+		<name>TYC 5409-2156-1</name>
+		<name>2MASS J07370922-1354239</name>
+		<spectraltype>G5IV-V/K2III</spectraltype>
 		<magB errorminus="0.08" errorplus="0.08">11.31</magB>
+		<magV errorminus="0.04" errorplus="0.04">10.04</magV>
 		<magJ errorminus="0.026" errorplus="0.026">7.940</magJ>
 		<magH errorminus="0.05" errorplus="0.05">7.37</magH>
 		<magK errorminus="0.023" errorplus="0.023">7.151</magK>
-		<metallicity>0.14</metallicity>
+		<metallicity errorminus="0.09" errorplus="0.09">0.14</metallicity>
+		<mass errorminus="0.2" errorplus="0.2">2.4</mass>
+		<age errorminus="0.20" errorplus="0.20">0.74</age>
 		<planet>
 			<name>NGC 2423 3 b</name>
+			<name>NGC 2423 MMU 3 b</name>
 			<name>BD-13 2130 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass>10.6</mass>
-			<period>714.3</period>
-			<semimajoraxis>2.1</semimajoraxis>
-			<eccentricity>0.21</eccentricity>
+			<mass type="msini">10.6</mass>
+			<period errorminus="5.3" errorplus="5.3">714.3</period>
+			<semimajoraxis>2.10</semimajoraxis>
+			<eccentricity errorminus="0.07" errorplus="0.07">0.21</eccentricity>
+			<periastron errorminus="10" errorplus="10">18</periastron>
+			<periastrontime errorminus="21" errorplus="21">2453213</periastrontime>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>07/11/27</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2007</discoveryyear>
-			<temperature>417.4</temperature>
+			<description>NGC 2423 MMU 3 b is a massive giant planet or brown dwarf orbiting a giant star in the open cluster NGC 2423.</description>
 		</planet>
-		<temperature>5700.0</temperature>
 	</star>
 </system>

--- a/systems/NGC 4349 No 127.xml
+++ b/systems/NGC 4349 No 127.xml
@@ -1,29 +1,34 @@
 <system>
 	<name>NGC 4349 No 127</name>
 	<name>NGC 4349 MMU 127</name>
-	<rightascension>12 24 08</rightascension>
-	<declination>-61 52 18</declination>
-	<distance>2176</distance>
+	<rightascension>12 24 35.4685</rightascension>
+	<declination>-61 49 11.888</declination>
+	<distance>2200</distance>
 	<star>
 		<name>NGC 4349 No 127</name>
 		<name>NGC 4349 MMU 127</name>
-		<mass>3.9</mass>
-		<magV>7.4</magV>
+		<name>TYC 8975-2606-1</name>
+		<magB errorminus="0.44" errorplus="0.44">12.85</magB>
+		<magV errorminus="0.08" errorplus="0.08">10.82</magV>
+		<metallicity errorminus="0.04" errorplus="0.04">-0.12</metallicity>
+		<mass errorminus="0.3" errorplus="0.3">3.9</mass>
+		<age errorminus="0.05" errorplus="0.05">0.20</age>
 		<planet>
 			<name>NGC 4349 No 127 b</name>
 			<name>NGC 4349 127 b</name>
 			<name>NGC 4349 MMU 127 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass>19.8</mass>
-			<period>677.8</period>
+			<mass type="msini">19.8</mass>
+			<period errorminus="6.2" errorplus="6.2">677.8</period>
 			<semimajoraxis>2.38</semimajoraxis>
-			<eccentricity>0.19</eccentricity>
+			<eccentricity errorminus="0.07" errorplus="0.07">0.19</eccentricity>
+			<periastron errorminus="19" errorplus="19">61</periastron>
+			<periastrontime errorminus="34" errorplus="34">2454114</periastrontime>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>07/11/27</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2007</discoveryyear>
-			<temperature>599.9</temperature>
+			<description>NGC 4349 MMU 127 b is a super-Jovian or brown dwarf orbiting a giant star in the open cluster NGC 4349.</description>
 		</planet>
-		<temperature>5700.0</temperature>
 	</star>
 </system>

--- a/systems/Pr0201.xml
+++ b/systems/Pr0201.xml
@@ -1,37 +1,45 @@
 <system>
 	<name>Pr0201</name>
-	<rightascension>08 41 43</rightascension>
-	<declination>+20 13 36</declination>
-	<distance>177</distance>
+	<rightascension>08 41 43.8157</rightascension>
+	<declination>+20 13 36.755</declination>
+	<distance errorminus="18" errorplus="18">178</distance>
 	<star>
-		<magB>11.1</magB>
-		<magV>10.33</magV>
+		<name>Pr0201</name>
+		<name>BD+20 2184</name>
+		<name>TYC 1398-321-1</name>
+		<name>EPIC 211998346</name>
+		<name>2MASS J08414382+2013368</name>
+		<magB errorminus="0.075" errorplus="0.075">11.109</magB>
+		<magV errorminus="0.053" errorplus="0.053">10.445</magV>
 		<magJ errorminus="0.023" errorplus="0.023">9.463</magJ>
 		<magH errorminus="0.020" errorplus="0.020">9.227</magH>
 		<magK errorminus="0.018" errorplus="0.018">9.142</magK>
-		<mass>1.234</mass>
-		<radius>1.167</radius>
-		<temperature>6174</temperature>
-		<metallicity>0.187</metallicity>
+		<mass errorminus="0.034" errorplus="0.034">1.234</mass>
+		<radius errorminus="0.121" errorplus="0.121">1.167</radius>
+		<temperature errorminus="50" errorplus="50">6174</temperature>
+		<metallicity errorminus="0.038" errorplus="0.038">0.187</metallicity>
 		<spectraltype>F7.5</spectraltype>
+		<age errorminus="0.049" errorplus="0.049">0.578</age>
 		<planet>
 			<name>Pr0201 b</name>
 			<name>BD+20 2184</name>
+			<name>EPIC 211998346 b</name>
 			<name>2MASS J08414382+2013368</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass>0.54</mass>
-			<period>4.4264</period>
+			<mass errorminus="0.039" errorplus="0.039" type="msini">0.540</mass>
+			<period errorminus="0.0070" errorplus="0.0070">4.4264</period>
 			<eccentricity>0</eccentricity>
+			<transittime errorminus="0.053" errorplus="0.053" unit="BJD">2455992.861</transittime>
+			<istransiting>0</istransiting>
 			<description>This planet is a so-called Hot Jupiter which orbits tightly around its parent star in the Beehive Cluster, a collection of roughly 1,000 stars that appear to be swarming around a common center. The planet is not habitable but its sky would be starrier than what we see from Earth.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>12/09/14</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2012</discoveryyear>
 			<image>beehive</image>
 			<imagedescription>Artist's impression of a planet in the Beehive cluster.
 
 Image credit: NASA/JPL-Caltech</imagedescription>
 		</planet>
-		<name>Pr0201</name>
 	</star>
 </system>

--- a/systems/Pr0211.xml
+++ b/systems/Pr0211.xml
@@ -5,6 +5,7 @@
 	<distance>177</distance>
 	<star>
 		<name>Pr0211</name>
+		<name>EPIC 211936827</name>
 		<name>2MASS J08421149+1916373</name>
 		<magB>13.02</magB>
 		<magV>12.15</magV>
@@ -22,15 +23,15 @@
 			<name>2MASS J08421149+1916373 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass errorminus="0.02" errorplus="0.02" type="msini">1.88</mass>
-			<period errorminus="0.00002" errorplus="0.00002">2.14609</period>
-			<eccentricity errorminus="0.010" errorplus="0.010">0.017</eccentricity>
-			<periastron errorminus="35" errorplus="35">329</periastron>
-			<semimajoraxis errorminus="0.00015" errorplus="0.00015">0.03184</semimajoraxis>
-			<periastrontime errorminus="0.2" errorplus="0.2">2456678.6</periastrontime>
+			<mass errorminus="0.03" errorplus="0.03" type="msini">1.88</mass>
+			<period errorminus="0.00003" errorplus="0.00003">2.14610</period>
+			<eccentricity errorminus="0.008" errorplus="0.012">0.011</eccentricity>
+			<periastron errorminus="111" errorplus="87">17</periastron>
+			<semimajoraxis errorminus="0.00015" errorplus="0.00015">0.03176</semimajoraxis>
+			<periastrontime errorminus="0.5" errorplus="0.5">2456678.8</periastrontime>
 			<description>This planet is a so-called Hot Jupiter which orbits tightly around its parent star in the Beehive Cluster, a collection of roughly 1,000 stars that appear to be swarming around a common center. The planet is not habitable but its sky would be starrier than what we see from Earth.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>16/03/03</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2012</discoveryyear>
 			<image>beehive</image>
 			<imagedescription>Artist's impression of a planet in the Beehive cluster.
@@ -42,16 +43,16 @@ Image credit: NASA/JPL-Caltech</imagedescription>
 			<name>2MASS J08421149+1916373 c</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<period errorminus="1800" errorplus="4450">5300</period>
-			<eccentricity errorminus="0.10" errorplus="0.10">0.70</eccentricity>
-			<periastron errorminus="6" errorplus="6">103</periastron>
-			<mass errorminus="0.25" errorplus="0.25" type="msini">7.95</mass>
-			<semimajoraxis errorminus="1.4" errorplus="2.9">5.8</semimajoraxis>
-			<periastrontime errorminus="16" errorplus="16">2456709</periastrontime>
+			<period errorminus="1750" errorplus="4560">4850</period>
+			<eccentricity errorminus="0.09" errorplus="0.09">0.78</eccentricity>
+			<periastron errorminus="9" errorplus="9">111</periastron>
+			<mass errorminus="0.33" errorplus="0.33" type="msini">7.79</mass>
+			<semimajoraxis errorminus="1.4" errorplus="3.0">5.5</semimajoraxis>
+			<periastrontime errorminus="22" errorplus="22">2456736</periastrontime>
 			<description>Pr0211 c is a super-Jovian planet in a highly-elliptical orbit. The discovery of this planet was the first time a multiplanet system had been observed in an open cluster.</description>
 			<discoverymethod>RV</discoverymethod>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/03/03</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 		</planet>
 	</star>
 </system>

--- a/systems/SAND364.xml
+++ b/systems/SAND364.xml
@@ -3,13 +3,16 @@
 	<name>NGC 2682 SAND 364</name>
 	<rightascension>08 49 56.5208</rightascension>
 	<declination>+11 41 32.989</declination>
-	<distance errorminus="50" errorplus="50">750</distance>
+	<distance errorminus="20" errorplus="20">843</distance>
 	<star>
 		<name>SAND364</name>
 		<name>NGC 2682 SAND 364</name>
 		<name>BD+12 1917</name>
-		<magB>11.22</magB>
-		<magV>9.77</magV>
+		<name>TYC 813-2344-1</name>
+		<name>EPIC 211403356</name>
+		<magB>11.2</magB>
+		<magV errorminus="0.056" errorplus="0.056">9.782</magV>
+		<magI>8.540</magI>
 		<magJ errorminus="0.027" errorplus="0.027">7.542</magJ>
 		<magH errorminus="0.018" errorplus="0.018">6.915</magH>
 		<magK>6.69</magK>
@@ -18,16 +21,18 @@
 		<temperature errorminus="9" errorplus="9">4284</temperature>
 		<metallicity errorminus="0.04" errorplus="0.04">-0.02</metallicity>
 		<spectraltype>K3III</spectraltype>
+		<age>4</age>
 		<planet>
 			<name>SAND364 b</name>
 			<name>NGC 2682 SAND 364 b</name>
 			<name>BD+12 1917 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass errorminus="0.24" errorplus="0.24">1.54</mass>
-			<period errorminus="0.305" errorplus="0.305">121.710</period>
-			<eccentricity errorminus="0.08" errorplus="0.08">0.35</eccentricity>
-			<periastron errorminus="12.81" errorplus="12.81">273.51</periastron>
+			<mass errorminus="0.11" errorplus="0.11" type="msini">1.57</mass>
+			<period errorminus="0.453" errorplus="0.453">120.951</period>
+			<eccentricity errorminus="0.10" errorplus="0.10">0.35</eccentricity>
+			<periastron errorminus="15.91" errorplus="15.91">254.62</periastron>
+			<periastrontime errorminus="4.26" errorplus="4.26">2456231.22</periastrontime>
 			<description>The host star of SAND364 b is located in the old open star cluster Messier 67 (M67). There are few galactic clusters which are older and none of those are as close as M67. The survey was conducted by European astronomers. They found that massive planets around stars of open clusters are as frequent as those around field stars.</description>
 			<discoverymethod>RV</discoverymethod>
 			<lastupdate>14/01/14</lastupdate>

--- a/systems/SAND978.xml
+++ b/systems/SAND978.xml
@@ -1,0 +1,41 @@
+<system>
+	<name>SAND978</name>
+	<name>NGC 2682 SAND 978</name>
+	<rightascension>08 51 17.4834</rightascension>
+	<declination>+11 45 22.693</declination>
+	<distance errorminus="20" errorplus="20">843</distance>
+	<star>
+		<name>SAND978</name>
+		<name>NGC 2682 SAND 978</name>
+		<name>TYC 814-2331-1</name>
+		<name>NSV 4275</name>
+		<name>EPIC 211407537</name>
+		<name>2MASS J08511747+1145226</name>
+		<magB errorminus="0.048" errorplus="0.048">11.064</magB>
+		<magV errorminus="0.022" errorplus="0.022">9.603</magV>
+		<magI>8.36</magI>
+		<magJ errorminus="0.021" errorplus="0.021">7.325</magJ>
+		<magH errorminus="0.020" errorplus="0.020">6.683</magH>
+		<magK errorminus="0.021" errorplus="0.021">6.494</magK>
+		<spectraltype>K4III</spectraltype>
+		<mass errorminus="0.02" errorplus="0.02">1.37</mass>
+		<temperature errorminus="21" errorplus="21">4200</temperature>
+		<age>4</age>
+		<metallicity>0</metallicity>
+		<planet>
+			<name>SAND978 b</name>
+			<name>NGC 2682 SAND 978 b</name>
+			<list>Confirmed planets</list>
+			<list>Planets in open clusters</list>
+			<period errorminus="2.04" errorplus="2.04">511.21</period>
+			<periastrontime errorminus="21.23" errorplus="21.23">2456135.92</periastrontime>
+			<eccentricity errorminus="0.07" errorplus="0.07">0.16</eccentricity>
+			<periastron errorminus="35.85" errorplus="35.85">291.68</periastron>
+			<mass errorminus="0.17" errorplus="0.17" type="msini">2.18</mass>
+			<discoverymethod>RV</discoverymethod>
+			<discoveryyear>2017</discoveryyear>
+			<description>SAND978 is a red giant star in the open cluster M67. A giant planet was discovered orbiting this star in 2017.</description>
+			<lastupdate>18/03/24</lastupdate>
+		</planet>
+	</star>
+</system>

--- a/systems/YBP1194.xml
+++ b/systems/YBP1194.xml
@@ -1,32 +1,41 @@
 <system>
 	<name>YBP1194</name>
+	<name>NGC 2682 YBP 1194</name>
 	<rightascension>08 51 00.807</rightascension>
 	<declination>+11 48 52.76</declination>
-	<distance errorminus="50" errorplus="50">850</distance>
+	<distance errorminus="20" errorplus="20">843</distance>
 	<star>
 		<name>YBP1194</name>
+		<name>NGC 2682 YBP 1194</name>
+		<name>NGC 2682 SAND 770</name>
+		<name>EPIC 211411531</name>
+		<name>2MASS J08510080+1148527</name>
+		<magU>15.546</magU>
 		<magB>15.28</magB>
-		<magV>14.61</magV>
+		<magV errorminus="0.156" errorplus="0.156">14.676</magV>
 		<magR>14.100</magR>
+		<magI errorminus="0.002" errorplus="0.002">13.876</magI>
 		<magJ errorminus="0.024" errorplus="0.024">13.366</magJ>
 		<magH errorminus="0.026" errorplus="0.026">13.041</magH>
 		<magK errorminus="0.029" errorplus="0.029">12.965</magK>
-		<mass errorminus="0.01" errorplus="0.01">1.01</mass>
+		<mass errorminus="0.02" errorplus="0.02">1.01</mass>
 		<radius errorminus="0.02" errorplus="0.02">0.99</radius>
 		<temperature errorminus="27" errorplus="27">5780</temperature>
 		<metallicity errorminus="0.015" errorplus="0.015">0.023</metallicity>
 		<spectraltype>G5V</spectraltype>
+		<age>4</age>
 		<planet>
 			<name>YBP1194 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass errorminus="0.05" errorplus="0.05">0.34</mass>
-			<period errorminus="0.001" errorplus="0.001">6.958</period>
-			<eccentricity errorminus="0.08" errorplus="0.08">0.24</eccentricity>
-			<periastron errorminus="25.68" errorplus="25.68">98.62</periastron>
-			<description>The star YBP1194 is one of the best solar twins identified so far. Its composition and age is very similar to that of our own Sun. It is located in the star cluster M67 and hosts a 0.34 Jupiter mass planet. The frequency of massive planets around stars of open clusters such as M67 turns out to be very similar to that of field stars.</description>
+			<mass errorminus="0.0305" errorplus="0.03" type="msini">0.3334</mass>
+			<period errorminus="0.001" errorplus="0.001">6.960</period>
+			<eccentricity errorminus="0.08" errorplus="0.08">0.31</eccentricity>
+			<periastron errorminus="20.16" errorplus="20.16">109.16</periastron>
+			<periastrontime errorminus="0.4" errorplus="0.4">2455679.9</periastrontime>
+			<description>The star YBP1194 is one of the best solar twins identified so far. Its composition and age is very similar to that of our own Sun. It is located in the star cluster M67 and hosts a 0.33 Jupiter mass planet. The frequency of massive planets around stars of open clusters such as M67 turns out to be very similar to that of field stars.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>14/01/14</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2014</discoveryyear>
 		</planet>
 	</star>

--- a/systems/YBP1514.xml
+++ b/systems/YBP1514.xml
@@ -3,13 +3,18 @@
 	<name>NGC 2682 YBP 1514</name>
 	<rightascension>08 51 00.766</rightascension>
 	<declination>+11 53 11.51</declination>
-	<distance errorminus="50" errorplus="50">750</distance>
+	<distance errorminus="20" errorplus="20">843</distance>
 	<star>
 		<name>YBP1514</name>
 		<name>NGC 2682 YBP 1514</name>
+		<name>NGC 2682 SAND 802</name>
+		<name>EPIC 211416296</name>
+		<name>2MASS J08510076+1153115</name>
+		<magU>15.766</magU>
 		<magB>15.50</magB>
-		<magV>14.78</magV>
+		<magV errorminus="0.091" errorplus="0.091">14.798</magV>
 		<magR>14.300</magR>
+		<magI>14.008</magI>
 		<magJ errorminus="0.024" errorplus="0.024">13.474</magJ>
 		<magH errorminus="0.023" errorplus="0.023">13.157</magH>
 		<magK errorminus="0.028" errorplus="0.028">13.105</magK>
@@ -18,18 +23,20 @@
 		<temperature errorminus="45" errorplus="45">5725</temperature>
 		<metallicity errorminus="0.05" errorplus="0.05">0.03</metallicity>
 		<spectraltype>G5V</spectraltype>
+		<age>4</age>
 		<planet>
 			<name>YBP1514 b</name>
 			<name>NGC 2682 YBP 1514 b</name>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<mass errorminus="0.11" errorplus="0.11">0.4</mass>
+			<mass errorminus="0.35" errorplus="0.35" type="msini">0.40</mass>
 			<period errorminus="0.001" errorplus="0.001">5.118</period>
-			<eccentricity errorminus="0.17" errorplus="0.17">0.39</eccentricity>
-			<periastron errorminus="16.05" errorplus="16.05">327.49</periastron>
+			<eccentricity errorminus="0.09" errorplus="0.09">0.27</eccentricity>
+			<periastron errorminus="17.78" errorplus="17.78">328.58</periastron>
+			<periastrontime errorminus="0.3" errorplus="0.3">2455986.3</periastrontime>
 			<description>YBP1514 is a main sequence star in the open star cluster M67. It hosts a 0.4 Jupiter mass planet. The star cluster is between 3.2 and 5 billion years old and contains many stars with ages and compositions similar to that of our own Sun.</description>
 			<discoverymethod>RV</discoverymethod>
-			<lastupdate>14/01/14</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<discoveryyear>2014</discoveryyear>
 		</planet>
 	</star>

--- a/systems/YBP401.xml
+++ b/systems/YBP401.xml
@@ -1,26 +1,39 @@
 <system>
 	<name>YBP401</name>
-	<rightascension>08 51 19</rightascension>
-	<declination>+11 40 16</declination>
-	<distance>843.0</distance>
+	<name>NGC 2682 YBP 401</name>
+	<rightascension>08 51 19.046</rightascension>
+	<declination>+11 40 15.67</declination>
+	<distance errorminus="20" errorplus="20">843</distance>
 	<star>
 		<name>YBP401</name>
-		<age>4.0</age>
-		<mass>1.14</mass>
+		<name>NGC 2682 YBP 401</name>
+		<name>NGC 2682 SAND 954</name>
+		<name>2MASS J08511904+1140156</name>
+		<magU>14.333</magU>
+		<magB>14.304</magB>
+		<magV errorminus="0.063" errorplus="0.063">13.723</magV>
+		<magI errorminus="0.003" errorplus="0.003">13.009</magI>
+		<magJ errorminus="0.022" errorplus="0.022">12.638</magJ>
+		<magH errorminus="0.022" errorplus="0.022">12.376</magH>
+		<magK errorminus="0.024" errorplus="0.024">12.337</magK>
 		<spectraltype>F9V</spectraltype>
-		<temperature>6165.0</temperature>
+		<temperature errorminus="64" errorplus="64">6165</temperature>
+		<mass errorminus="0.02" errorplus="0.02">1.14</mass>
+		<age>4</age>
+		<metallicity>0</metallicity>
 		<planet>
 			<name>YBP401 b</name>
-			<periastron errorminus="26.0" errorplus="26.0">330.17</periastron>
-			<eccentricity errorminus="0.08" errorplus="0.08">0.15</eccentricity>
-			<period errorminus="0.070000" errorplus="0.070000">4.087</period>
-			<mass errorminus="0.05" errorplus="0.05">0.46</mass>
+			<periastron errorminus="62.12" errorplus="62.12">343.33</periastron>
+			<eccentricity errorminus="0.08" errorplus="0.08">0.16</eccentricity>
+			<period errorminus="0.003" errorplus="0.003">4.087</period>
+			<mass errorminus="0.05" errorplus="0.05" type="msini">0.42</mass>
+			<periastrontime errorminus="0.6" errorplus="0.6">2456072.4</periastrontime>
 			<discoverymethod>RV</discoverymethod>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/06/18</lastupdate>
+			<lastupdate>18/03/23</lastupdate>
 			<list>Confirmed planets</list>
 			<list>Planets in open clusters</list>
-			<description>Data for this planet was imported from the exoplanet.eu database.</description>
+			<description>YBP401 b is a hot Jupiter in an eccentric orbit around an F-type star in the open cluster M67.</description>
 		</planet>
 	</star>
 </system>


### PR DESCRIPTION
New systems K2-231, K2-136, EPIC 211901114 (candidate) and SAND978, plus maintenance on other open cluster planets listed in [Curtis et al. (2018)](https://arxiv.org/abs/1803.07430). Details in individual commit messages.