### PR TITLE
Fix duplicate names

### DIFF
--- a/systems/Epsilon Indi.xml
+++ b/systems/Epsilon Indi.xml
@@ -87,7 +87,6 @@
 				<name>ε Ind Ba</name>
 				<name>ε Indi Ba</name>
 				<name>GJ 845 Ba</name>
-				<name>GJ 845 Bb</name>
 				<name>CI Indi A</name>
 				<name>CI Ind A</name>
 				<name>WDS J22034-5647 Ba</name>

--- a/systems/omi CrB.xml
+++ b/systems/omi CrB.xml
@@ -1,6 +1,5 @@
 <system>
 	<name>omi CrB</name>
-	<name>omi CrB</name>
 	<rightascension>15 20 08.55879</rightascension>
 	<declination>+29 36 58.3488</declination>
 	<distance errorminus="3.0" errorplus="3.0">82.8</distance>


### PR DESCRIPTION
Duplicate names GJ 845 Bb (accidentally also applied to the Ba component) and omi CrB.