### PR TITLE
Update Kepler-503: companion is non-planetary

### DIFF
--- a/systems/Kepler-503.xml
+++ b/systems/Kepler-503.xml
@@ -2,31 +2,42 @@
 	<name>Kepler-503</name>
 	<name>KOI-242</name>
 	<name>KIC 3642741</name>
-	<rightascension>19 22 33</rightascension>
-	<declination>+38 42 28</declination>
+	<rightascension>19 22 32.7571937112</rightascension>
+	<declination>+38 42 27.579129047</declination>
+	<distance errorminus="55" errorplus="55">1628</distance>
 	<star>
 		<name>Kepler-503</name>
 		<name>KOI-242</name>
 		<name>KIC 3642741</name>
 		<name>2MASS J19223275+3842276</name>
-		<temperature errorminus="137.9" errorplus="89.0">5754.0</temperature>
-		<mass errorminus="0.06" errorplus="0.06">1.01</mass>
-		<radius errorminus="0.09" errorplus="0.23">1.01</radius>
-		<metallicity errorminus="0.16" errorplus="0.14">0.09</metallicity>
+		<name>Gaia DR2 2052853703021795456</name>
+		<magJ errorminus="0.025" errorplus="0.025">13.461</magJ>
+		<magH errorminus="0.026" errorplus="0.026">13.138</magH>
+		<magK errorminus="0.028" errorplus="0.028">13.045</magK>
+		<temperature errorminus="110" errorplus="100">5670</temperature>
+		<mass errorminus="0.042" errorplus="0.047">1.154</mass>
+		<radius errorminus="0.068" errorplus="0.080">1.764</radius>
+		<metallicity errorminus="0.045" errorplus="0.046">0.169</metallicity>
+		<age errorminus="0.9" errorplus="1.0">6.7</age>
 		<planet>
 			<name>Kepler-503 b</name>
 			<name>KOI-242 b</name>
 			<name>KOI-242.01</name>
 			<name>KIC 3642741 b</name>
 			<discoverymethod>transit</discoverymethod>
-			<list>Confirmed planets</list>
+			<list>Retracted planet candidate</list>
 			<discoveryyear>2016</discoveryyear>
-			<lastupdate>16/05/10</lastupdate>
+			<lastupdate>18/08/16</lastupdate>
 			<istransiting>1</istransiting>
-			<new>1</new>
-			<description>This planet was discovered by the NASA Kepler spacecraft and is part of the May 10th 2016 data release. Although not many details are known about this particular system yet, it has a very low probability of being a false positive.</description>
-			<period errorminus="0.000002820" errorplus="0.000002820">7.258447210</period>
-			<radius errorminus="0.051" errorplus="0.128">0.559</radius>
+			<description>This planet was discovered by the NASA Kepler spacecraft and is part of the May 10th 2016 data release. Subsequent radial velocity analysis combined with the Gaia parallax revealed that the host star is a subgiant and the companion is at the hydrogen-burning limit.</description>
+			<period errorminus="0.0000023" errorplus="0.0000023">7.2584481</period>
+			<radius errorminus="0.06" errorplus="0.04">0.96</radius>
+			<mass errorminus="3" errorplus="3">79</mass>
+			<transittime errorminus="0.00026" errorplus="0.00026" unit="BJD">2454971.34494</transittime>
+			<semimajoraxis errorminus="0.0010" errorplus="0.0010">0.0786</semimajoraxis>
+			<eccentricity errorminus="0.012" errorplus="0.014">0.025</eccentricity>
+			<periastron errorminus="54" errorplus="32">33</periastron>
+			<inclination errorminus="0.76" errorplus="1.0">88.04</inclination>
 		</planet>
 	</star>
 </system>


### PR DESCRIPTION
Updated system data from [Cañas et al. (2018)](http://adsabs.harvard.edu/abs/2018ApJ...861L...4C)

Coordinates, magnitudes and Gaia identifier from SIMBAD